### PR TITLE
Add full settings key to color group to allow override

### DIFF
--- a/inc/css-output.php
+++ b/inc/css-output.php
@@ -343,7 +343,7 @@ if ( ! function_exists( 'generate_advanced_css' ) ) {
 		$css->set_selector( '.main-navigation .main-nav ul ul li a' );
 		$css->add_property( 'color', $settings['subnavigation_text_color'] );
 
-		$css->set_selector( '.main-navigation .main-nav ul ul li:not([class*="current-menu-"]):hover > a,.main-navigation .main-nav ul ul li:not([class*="current-menu-"]):focus > a,.main-navigation .main-nav ul ul li:not([class*="current-menu-"]).sfHover > a' );
+		$css->set_selector( '.main-navigation .main-nav ul ul li:not([class*="current-menu-"]):hover > a,.main-navigation .main-nav ul ul li:not([class*="current-menu-"]):focus > a, .main-navigation .main-nav ul ul li:not([class*="current-menu-"]).sfHover > a' );
 		$css->add_property( 'color', $settings['subnavigation_text_hover_color'] );
 		$css->add_property( 'background-color', $settings['subnavigation_background_hover_color'] );
 

--- a/inc/css-output.php
+++ b/inc/css-output.php
@@ -343,7 +343,7 @@ if ( ! function_exists( 'generate_advanced_css' ) ) {
 		$css->set_selector( '.main-navigation .main-nav ul ul li a' );
 		$css->add_property( 'color', $settings['subnavigation_text_color'] );
 
-		$css->set_selector( '.main-navigation .main-nav ul ul li:not([class*="current-menu-"]):hover > a,.main-navigation .main-nav ul ul li:not([class*="current-menu-"]):focus > a, .main-navigation .main-nav ul ul li:not([class*="current-menu-"]).sfHover > a' );
+		$css->set_selector( '.main-navigation .main-nav ul ul li:not([class*="current-menu-"]):hover > a,.main-navigation .main-nav ul ul li:not([class*="current-menu-"]):focus > a, .main-navigation .main-nav ul ul li.sfHover:not([class*="current-menu-"]) > a' );
 		$css->add_property( 'color', $settings['subnavigation_text_hover_color'] );
 		$css->add_property( 'background-color', $settings['subnavigation_background_hover_color'] );
 

--- a/inc/customizer/class-customize-field.php
+++ b/inc/customizer/class-customize-field.php
@@ -172,7 +172,7 @@ class GeneratePress_Customize_Field {
 
 		foreach ( $fields as $key => $field ) {
 			self::add_field(
-				"generate_settings[$key]",
+				$key,
 				'GeneratePress_Customize_Color_Control',
 				array(
 					'default' => $field['default_value'],

--- a/inc/customizer/fields/primary-navigation.php
+++ b/inc/customizer/fields/primary-navigation.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $menu_hover_selectors = '.navigation-search input[type="search"], .navigation-search input[type="search"]:active, .navigation-search input[type="search"]:focus, .main-navigation .main-nav ul li:not([class*="current-menu-"]):hover > a, .main-navigation .main-nav ul li:not([class*="current-menu-"]):focus > a, .main-navigation .main-nav ul li.sfHover:not([class*="current-menu-"]) > a, .main-navigation .menu-bar-item:hover > a, .main-navigation .menu-bar-item.sfHover > a';
 $menu_current_selectors = '.main-navigation .main-nav ul li[class*="current-menu-"] > a';
-$submenu_hover_selectors = '.main-navigation .main-nav ul ul li:not([class*="current-menu-"]):hover > a,.main-navigation .main-nav ul ul li:not([class*="current-menu-"]):focus > a,.main-navigation .main-nav ul ul li:not([class*="current-menu-"]).sfHover > a';
+$submenu_hover_selectors = '.main-navigation .main-nav ul ul li:not([class*="current-menu-"]):hover > a,.main-navigation .main-nav ul ul li:not([class*="current-menu-"]):focus > a,.main-navigation .main-nav ul ul li.sfHover:not([class*="current-menu-"]) > a';
 $submenu_current_selectors = '.main-navigation .main-nav ul ul li[class*="current-menu-"] > a';
 
 GeneratePress_Customize_Field::add_title(

--- a/inc/customizer/fields/primary-navigation.php
+++ b/inc/customizer/fields/primary-navigation.php
@@ -33,7 +33,7 @@ GeneratePress_Customize_Field::add_color_field_group(
 	'generate_colors_section',
 	'primary-navigation-colors',
 	array(
-		'navigation_background_color' => array(
+		'generate_settings[navigation_background_color]' => array(
 			'default_value' => $color_defaults['navigation_background_color'],
 			'label' => __( 'Navigation Background', 'generatepress' ),
 			'tooltip' => __( 'Choose Initial Color', 'generatepress' ),
@@ -41,7 +41,7 @@ GeneratePress_Customize_Field::add_color_field_group(
 			'property' => 'background-color',
 			'hide_label' => false,
 		),
-		'navigation_background_hover_color' => array(
+		'generate_settings[navigation_background_hover_color]' => array(
 			'default_value' => $color_defaults['navigation_background_hover_color'],
 			'label' => __( 'Navigation Background Hover', 'generatepress' ),
 			'tooltip' => __( 'Choose Hover Color', 'generatepress' ),
@@ -49,7 +49,7 @@ GeneratePress_Customize_Field::add_color_field_group(
 			'property' => 'background-color',
 			'hide_label' => true,
 		),
-		'navigation_background__current_color' => array(
+		'generate_settings[navigation_background_current_color]' => array(
 			'default_value' => $color_defaults['navigation_background_current_color'],
 			'label' => __( 'Navigation Background Current', 'generatepress' ),
 			'tooltip' => __( 'Choose Current Color', 'generatepress' ),
@@ -66,7 +66,7 @@ GeneratePress_Customize_Field::add_color_field_group(
 	'generate_colors_section',
 	'primary-navigation-colors',
 	array(
-		'navigation_text_color' => array(
+		'generate_settings[navigation_text_color]' => array(
 			'default_value' => $color_defaults['navigation_text_color'],
 			'label' => __( 'Navigation Text', 'generatepress' ),
 			'tooltip' => __( 'Choose Initial Color', 'generatepress' ),
@@ -74,7 +74,7 @@ GeneratePress_Customize_Field::add_color_field_group(
 			'property' => 'color',
 			'hide_label' => false,
 		),
-		'navigation_text_hover_color' => array(
+		'generate_settings[navigation_text_hover_color]' => array(
 			'default_value' => $color_defaults['navigation_text_hover_color'],
 			'label' => __( 'Navigation Text Hover', 'generatepress' ),
 			'tooltip' => __( 'Choose Hover Color', 'generatepress' ),
@@ -82,7 +82,7 @@ GeneratePress_Customize_Field::add_color_field_group(
 			'property' => 'color',
 			'hide_label' => true,
 		),
-		'navigation_text_current_color' => array(
+		'generate_settings[navigation_text_current_color]' => array(
 			'default_value' => $color_defaults['navigation_text_current_color'],
 			'label' => __( 'Navigation Text Current', 'generatepress' ),
 			'tooltip' => __( 'Choose Current Color', 'generatepress' ),
@@ -99,7 +99,7 @@ GeneratePress_Customize_Field::add_color_field_group(
 	'generate_colors_section',
 	'primary-navigation-colors',
 	array(
-		'subnavigation_background_color' => array(
+		'generate_settings[subnavigation_background_color]' => array(
 			'default_value' => $color_defaults['subnavigation_background_color'],
 			'label' => __( 'Sub-Menu Background', 'generatepress' ),
 			'tooltip' => __( 'Choose Initial Color', 'generatepress' ),
@@ -107,7 +107,7 @@ GeneratePress_Customize_Field::add_color_field_group(
 			'property' => 'background-color',
 			'hide_label' => false,
 		),
-		'subnavigation_background_hover_color' => array(
+		'generate_settings[subnavigation_background_hover_color]' => array(
 			'default_value' => $color_defaults['subnavigation_background_hover_color'],
 			'label' => __( 'Sub-Menu Background Hover', 'generatepress' ),
 			'tooltip' => __( 'Choose Hover Color', 'generatepress' ),
@@ -115,7 +115,7 @@ GeneratePress_Customize_Field::add_color_field_group(
 			'property' => 'background-color',
 			'hide_label' => true,
 		),
-		'subnavigation_background_current_color' => array(
+		'generate_settings[subnavigation_background_current_color]' => array(
 			'default_value' => $color_defaults['subnavigation_background_current_color'],
 			'label' => __( 'Sub-Menu Background Current', 'generatepress' ),
 			'tooltip' => __( 'Choose Current Color', 'generatepress' ),
@@ -132,7 +132,7 @@ GeneratePress_Customize_Field::add_color_field_group(
 	'generate_colors_section',
 	'primary-navigation-colors',
 	array(
-		'subnavigation_text_color' => array(
+		'generate_settings[subnavigation_text_color]' => array(
 			'default_value' => $color_defaults['subnavigation_text_color'],
 			'label' => __( 'Sub-Menu Text', 'generatepress' ),
 			'tooltip' => __( 'Choose Initial Color', 'generatepress' ),
@@ -140,7 +140,7 @@ GeneratePress_Customize_Field::add_color_field_group(
 			'property' => 'color',
 			'hide_label' => false,
 		),
-		'subnavigation_text_hover_color' => array(
+		'generate_settings[subnavigation_text_hover_color]' => array(
 			'default_value' => $color_defaults['subnavigation_text_hover_color'],
 			'label' => __( 'Sub-Menu Text Hover', 'generatepress' ),
 			'tooltip' => __( 'Choose Hover Color', 'generatepress' ),
@@ -148,7 +148,7 @@ GeneratePress_Customize_Field::add_color_field_group(
 			'property' => 'color',
 			'hide_label' => true,
 		),
-		'subnavigation_text_current_color' => array(
+		'generate_settings[subnavigation_text_current_color]' => array(
 			'default_value' => $color_defaults['subnavigation_text_current_color'],
 			'label' => __( 'Sub-Menu Text Current', 'generatepress' ),
 			'tooltip' => __( 'Choose Current Color', 'generatepress' ),


### PR DESCRIPTION
This is to allow GPP to override the settings namespace. Related to https://github.com/tomusborne/gp-premium/pull/198