### PR TITLE
Add generate_search_title_output filter

### DIFF
--- a/inc/structure/archives.php
+++ b/inc/structure/archives.php
@@ -115,3 +115,27 @@ function generate_do_archive_description() {
 	 */
 	do_action( 'generate_after_archive_description' );
 }
+
+add_action( 'generate_before_loop', 'generate_do_search_results_title' );
+/**
+ * Add the search results title to the search results page.
+ *
+ * @since 3.1.0
+ * @param string $template The template we're targeting.
+ */
+function generate_do_search_results_title( $template ) {
+	if ( 'search' === $template ) {
+		// phpcs:ignore -- No escaping needed.
+		echo apply_filters(
+			'generate_search_title_output',
+			sprintf(
+				'<header class="page-header"><h1 class="page-title">%s</h1></header>',
+				sprintf(
+					/* translators: 1: Search query name */
+					__( 'Search Results for: %s', 'generatepress' ),
+					'<span>' . get_search_query() . '</span>'
+				)
+			)
+		);
+	}
+}

--- a/search.php
+++ b/search.php
@@ -23,19 +23,6 @@ get_header(); ?>
 
 			if ( generate_has_default_loop() ) {
 				if ( have_posts() ) :
-					// phpcs:ignore -- No escaping needed.
-					echo apply_filters(
-						'generate_search_title_output',
-						sprintf(
-							'<header class="page-header"><h1 class="page-title">%s</h1></header>',
-							sprintf(
-								/* translators: 1: Search query name */
-								__( 'Search Results for: %s', 'generatepress' ),
-								'<span>' . get_search_query() . '</span>'
-							)
-						)
-					);
-
 					/**
 					 * generate_before_loop hook.
 					 *

--- a/search.php
+++ b/search.php
@@ -23,23 +23,18 @@ get_header(); ?>
 
 			if ( generate_has_default_loop() ) {
 				if ( have_posts() ) :
-					if ( apply_filters( 'generate_show_search_page_title', true ) ) :
-						?>
-
-						<header class="page-header">
-							<h1 class="page-title">
-								<?php
-								printf(
-									/* translators: 1: Search query name */
-									__( 'Search Results for: %s', 'generatepress' ),
-									'<span>' . get_search_query() . '</span>'
-								);
-								?>
-							</h1>
-						</header>
-
-						<?php
-					endif;
+					// phpcs:ignore -- No escaping needed.
+					echo apply_filters(
+						'generate_search_title_output',
+						sprintf(
+							'<header class="page-header"><h1 class="page-title">%s</h1></header>',
+							sprintf(
+								/* translators: 1: Search query name */
+								__( 'Search Results for: %s', 'generatepress' ),
+								'<span>' . get_search_query() . '</span>'
+							)
+						)
+					);
 
 					/**
 					 * generate_before_loop hook.


### PR DESCRIPTION
This wraps our search page title in a filter so it can be changed/removed without a child theme template.

It also hooks it into the template so you can hook things in before it using `generate_before_loop`.

This should be fine when it comes to backward-compatibility, as `generate_before_loop` is being introduced in the same version. Therefore we shouldn't get double titles for people using a `search.php` template in their child themes.

It also removes the `generate_show_search_page_title` filter, but it's new to 3.1.0 as well and isn't necessary with this PR.