### PR TITLE
Pass $type to the generate_typography_css_selector filter

### DIFF
--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -308,7 +308,7 @@ class GeneratePress_Typography {
 			}
 		}
 
-		return apply_filters( 'generate_typography_css_selector', $selector );
+		return apply_filters( 'generate_typography_css_selector', $selector, $type );
 	}
 
 	/**


### PR DESCRIPTION
This passes the `$type` param to the `generate_typography_css_selector` filter.