### PR TITLE
Load viewport tag earlier

### DIFF
--- a/inc/structure/header.php
+++ b/inc/structure/header.php
@@ -378,7 +378,7 @@ if ( ! function_exists( 'generate_pingback_header' ) ) {
 }
 
 if ( ! function_exists( 'generate_add_viewport' ) ) {
-	add_action( 'wp_head', 'generate_add_viewport' );
+	add_action( 'wp_head', 'generate_add_viewport', 1 );
 	/**
 	 * Add viewport to wp_head.
 	 *


### PR DESCRIPTION
This loads the viewport tag after the `<title>` tag in `wp_head`.

Closes #210 