### PR TITLE
Add GitHub actions for PHP

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -1,0 +1,38 @@
+name: GeneratePress PHP CI
+
+on:
+  push:
+    branches:
+    - master
+    - 'release/**'
+  pull_request:
+    branches:
+      - master
+      - 'release/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Validate composer.json
+        run: composer validate
+
+      - name: Check vendor cache
+        id: vendor-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-vendor-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-vendor-
+
+      - name: Composer install
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress
+
+      - name: Composer lint
+        run: composer php


### PR DESCRIPTION
This is the first step to add GitHub actions. It's supposed to run `composer lint` every time a `push` or `pull_request` is made on `master` or `release/**`.

The next steps are to start migrating Grunt scripts to Webpack and add JS linting/tests.