### PR TITLE
Add utility classes for global colors

### DIFF
--- a/inc/css-output.php
+++ b/inc/css-output.php
@@ -243,6 +243,16 @@ if ( ! function_exists( 'generate_base_css' ) ) {
 					$css->add_property( '--' . $data['slug'], $data['color'] );
 				}
 			}
+
+			foreach ( (array) $global_colors as $key => $data ) {
+				if ( ! empty( $data['slug'] ) && ! empty( $data['color'] ) ) {
+					$css->set_selector( '.has-' . $data['slug'] . '-color' );
+					$css->add_property( 'color', $data['color'] );
+
+					$css->set_selector( '.has-' . $data['slug'] . '-background-color' );
+					$css->add_property( 'background-color', $data['color'] );
+				}
+			}
 		}
 
 		do_action( 'generate_base_css', $css );


### PR DESCRIPTION
Closes #237 

This adds the utility classes for our global colors so they work with core blocks.

To test, add a paragraph block and use our global colors as the text color.

Same with the Group block - use our global colors as the background color.

This should make them work on the front end.