### PR TITLE
Fix unable to save new global colors

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -256,12 +256,12 @@ if ( ! function_exists( 'generate_customize_register' ) ) {
 					}
 
 					foreach ( (array) $colors as $key => $data ) {
-						if ( empty( $data['name'] ) || empty( $data['color'] ) ) {
+						if ( empty( $data['slug'] ) || empty( $data['color'] ) ) {
 							unset( $colors[ $key ] );
 							continue;
 						}
 
-						$slug = str_replace( ' ', '-', strtolower( $data['name'] ) );
+						$slug = str_replace( ' ', '-', strtolower( $data['slug'] ) );
 						$colors[ $key ]['name'] = sanitize_text_field( $slug );
 						$colors[ $key ]['color'] = generate_sanitize_rgba_color( $data['color'] );
 					}


### PR DESCRIPTION
The bug was introduced when the slug property was added to the global colors array. The validation was expecting a `name` property, but the frontend was sending the `slug`. Not sure how we did not catch this before.

https://github.com/tomusborne/generatepress/commit/86363c510404786d0ddc7eb1395a2e7be628d9cb

Closes #242 