### PR TITLE
Only load dashboard.js on main dashboard

### DIFF
--- a/inc/class-dashboard.php
+++ b/inc/class-dashboard.php
@@ -200,29 +200,31 @@ class GeneratePress_Dashboard {
 				GENERATE_VERSION
 			);
 
-			wp_enqueue_script(
-				'generate-dashboard',
-				get_template_directory_uri() . '/assets/dist/dashboard.js',
-				array( 'wp-api', 'wp-i18n', 'wp-components', 'wp-element', 'wp-api-fetch' ),
-				GENERATE_VERSION,
-				true
-			);
+			if ( 'appearance_page_generate-options' === $current_screen->id ) {
+				wp_enqueue_script(
+					'generate-dashboard',
+					get_template_directory_uri() . '/assets/dist/dashboard.js',
+					array( 'wp-api', 'wp-i18n', 'wp-components', 'wp-element', 'wp-api-fetch' ),
+					GENERATE_VERSION,
+					true
+				);
 
-			wp_set_script_translations( 'generate-dashboard', 'generatepress' );
+				wp_set_script_translations( 'generate-dashboard', 'generatepress' );
 
-			wp_localize_script(
-				'generate-dashboard',
-				'generateDashboard',
-				array(
-					'hasPremium' => defined( 'GP_PREMIUM_VERSION' ),
-					'customizeSectionUrls' => array(
-						'siteIdentitySection' => admin_url( 'customize.php?autofocus[section]=title_tagline' ),
-						'colorsSection' => admin_url( 'customize.php?autofocus[section]=generate_colors_section' ),
-						'typographySection' => admin_url( 'customize.php?autofocus[section]=generate_typography_section' ),
-						'layoutSection' => admin_url( 'customize.php?autofocus[section]=generate_layout_panel' ),
-					),
-				)
-			);
+				wp_localize_script(
+					'generate-dashboard',
+					'generateDashboard',
+					array(
+						'hasPremium' => defined( 'GP_PREMIUM_VERSION' ),
+						'customizeSectionUrls' => array(
+							'siteIdentitySection' => admin_url( 'customize.php?autofocus[section]=title_tagline' ),
+							'colorsSection' => admin_url( 'customize.php?autofocus[section]=generate_colors_section' ),
+							'typographySection' => admin_url( 'customize.php?autofocus[section]=generate_typography_section' ),
+							'layoutSection' => admin_url( 'customize.php?autofocus[section]=generate_layout_panel' ),
+						),
+					)
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
This loads dashboard.js only on the main dashboard page, not other dashboard pages (Site Library, Elements etc..).

This prevents the following errors: https://www.screencast.com/t/kn36gPPDoz1

Not sure if it would be better to check for the existence of the element before using `render()`, or to use this method (not load the JS at all).