### PR TITLE
Remove git hooks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -299,8 +299,7 @@ module.exports = function (grunt) {
 					}
                 })
 
-                fs.writeFile('src/customizer-controls/font-manager/google-fonts.json', JSON.stringify(fonts, undefined, 4), function (err) {
-                    console.log(err ?? 'Google Fonts Updated!');
+                fs.writeFile('src/customizer-controls/font-manager/google-fonts.json', JSON.stringify(fonts, undefined, 4), function () {
                     done();
                 });
             }

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         "wptrt/wpthemereview": "^0.2.1",
         "php-parallel-lint/php-parallel-lint": "^1.2.0",
         "phpcompatibility/phpcompatibility-wp": "^2.1.0",
-        "wp-cli/i18n-command": "^2.2.5",
-        "brainmaestro/composer-git-hooks": "^2.8"
+        "wp-cli/i18n-command": "^2.2.5"
     },
     "scripts": {
         "php": [
@@ -32,24 +31,10 @@
 		],
         "lint:wpcs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
         "lint:php": "@php ./vendor/bin/parallel-lint --exclude .git --exclude vendor .",
-        "make-pot": "wp i18n make-pot . languages/_s.pot",
-	  	"post-install-cmd": "cghooks add --ignore-lock",
-	  	"post-update-cmd": "cghooks update"
+        "make-pot": "wp i18n make-pot . languages/_s.pot"
 	},
     "support": {
         "issues": "https://github.com/tomusborne/generatepress/issues",
         "source": "https://github.com/tomusborne/generatepress"
-    },
-  	"extra": {
-	  	"hooks": {
-		  	"config": {
-				"stop-on-failure": ["pre-commit"]
-		  	},
-			"pre-commit": [
-			  	"printf \"\\033[36mChecking PHPCS...\\033[0m\\n\"",
-		  		"./vendor/bin/phpcs --standard=phpcs.xml.dist",
-			  	"printf \"\\033[42mCOMMIT CHECK SUCCEEDED\\033[0m\\n\""
-			]
-	  	}
-	}
+    }
 }


### PR DESCRIPTION
Shouldn't need these now that we have GH actions, especially as they slow down the commit process.

The `??` was preventing Grunt from doing anything - figured we can just remove the `console.log()` completely.