### PR TITLE
Apply all underline options to editor links

### DIFF
--- a/assets/css/admin/block-editor.css
+++ b/assets/css/admin/block-editor.css
@@ -1,3 +1,7 @@
+.wp-block a {
+	text-decoration: none;
+}
+
 .block-editor-block-list__layout pre {
 	background: rgba(0, 0, 0, 0.05);
 	font-family: inherit;

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -216,14 +216,28 @@ function generate_do_inline_block_editor_css() {
 	$css->set_selector( '.wp-block[data-align="wide"]' );
 	$css->add_property( 'max-width', absint( $content_width ), false, 'px' );
 
-	if ( generate_get_option( 'underline_links' ) ) {
-		$css->set_selector( '.wp-block a' );
-		$css->add_property( 'text-decoration', 'underline' );
+	$underline_links = generate_get_option( 'underline_links' );
 
-		$css->set_selector( 'a.button' );
-		$css->add_property( 'text-decoration', 'none' );
-	} else {
-		$css->set_selector( '.wp-block a' );
+	if ( 'never' !== $underline_links ) {
+		if ( 'always' === $underline_links ) {
+			$css->set_selector( '.wp-block a' );
+			$css->add_property( 'text-decoration', 'underline' );
+		}
+
+		if ( 'hover' === $underline_links ) {
+			$css->set_selector( '.wp-block a:hover, .wp-block a:focus' );
+			$css->add_property( 'text-decoration', 'underline' );
+		}
+
+		if ( 'not-hover' === $underline_links ) {
+			$css->set_selector( '.wp-block a' );
+			$css->add_property( 'text-decoration', 'underline' );
+
+			$css->set_selector( '.wp-block a:hover, .wp-block a:focus' );
+			$css->add_property( 'text-decoration', 'none' );
+		}
+
+		$css->set_selector( 'a.button, .wp-block-button__link' );
 		$css->add_property( 'text-decoration', 'none' );
 	}
 


### PR DESCRIPTION
All of our link underline options weren't added to the block editor CSS. This adds them so each option applies correctly when inside the editor.