### PR TITLE
Prevent classes in generate_get_attr() from being overwritten

### DIFF
--- a/inc/theme-functions.php
+++ b/inc/theme-functions.php
@@ -692,7 +692,7 @@ function generate_parse_attr( $context, $attributes = array(), $settings = array
 	$classes = generate_get_element_classes( $context );
 
 	if ( $classes ) {
-		$attributes['class'] = join( ' ', $classes );
+		$attributes['class'] .= join( ' ', $classes );
 	}
 
 	// Contextual filter.

--- a/inc/theme-functions.php
+++ b/inc/theme-functions.php
@@ -684,7 +684,9 @@ function generate_needs_site_branding_container() {
  */
 function generate_parse_attr( $context, $attributes = array(), $settings = array() ) {
 	// Initialize an empty class attribute so it's easier to append to in filters.
-	$attributes['class'] = '';
+	if ( ! isset( $attributes['class'] ) ) {
+		$attributes['class'] = '';
+	}
 
 	// We used to have a class-only system. If it's in use, add the classes.
 	$classes = generate_get_element_classes( $context );


### PR DESCRIPTION
This prevents classes being fed directly into `generate_get_attr()` from being overwritten.

This fixes a bug where the mobile header in GPP 2.1.0 losing styling.

To test, enable Mobile Header in GPP 2.1.0 and GP 3.0.4, then update to `release/3.1.0` branch. You'll see the mobile header loses all styling.