### PR TITLE
Fix duplicated fonts on migrating to new typography system

### DIFF
--- a/inc/class-typography-migration.php
+++ b/inc/class-typography-migration.php
@@ -249,7 +249,7 @@ class GeneratePress_Typography_Migration {
 			if ( self::has_saved_value( 'font_' . $data['legacy_prefix'], $settings, $defaults ) ) {
 				$has_font = array_search( $settings[ 'font_' . $data['legacy_prefix'] ], array_column( $font_mapping, 'fontFamily' ) );
 
-				if ( $has_font !== false ) {
+				if ( false !== $has_font ) {
 					continue;
 				}
 

--- a/inc/class-typography-migration.php
+++ b/inc/class-typography-migration.php
@@ -249,7 +249,7 @@ class GeneratePress_Typography_Migration {
 			if ( self::has_saved_value( 'font_' . $data['legacy_prefix'], $settings, $defaults ) ) {
 				$has_font = array_search( $settings[ 'font_' . $data['legacy_prefix'] ], array_column( $font_mapping, 'fontFamily' ) );
 
-				if ( $has_font ) {
+				if ( $has_font !== false ) {
 					continue;
 				}
 


### PR DESCRIPTION
This fixes the duplicated fonts generated by the typography system migration.

The `array_search` returned a non-Boolean value which evaluates to false (the index 0) so we just need to tighten up the check.