### PR TITLE
Exclude src folder from package

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -229,6 +229,7 @@ module.exports = function (grunt) {
                     '!composer.lock',
                     '!package-lock.json',
                     '!phpcs.xml.dist',
+                    '!src/**',
                 ],
                 dest: 'generatepress/'
             }


### PR DESCRIPTION
This excludes the `src` folder from the `.zip` package.