### PR TITLE
Add default theme styling to headings in editor

### DIFF
--- a/assets/css/admin/editor-typography.css
+++ b/assets/css/admin/editor-typography.css
@@ -12,6 +12,13 @@
 	margin-bottom: 1.5em;
 }
 
+.editor-styles-wrapper h1, .editor-styles-wrapper h2, .editor-styles-wrapper h3, .editor-styles-wrapper h4, .editor-styles-wrapper h5, .editor-styles-wrapper h6 {
+	font-family: inherit;
+	font-size: 100%;
+	font-style: inherit;
+	font-weight: inherit;
+}
+
 .editor-styles-wrapper h1,
 .editor-styles-wrapper .editor-post-title__input {
 	font-family: inherit;

--- a/sass/editor-typography.scss
+++ b/sass/editor-typography.scss
@@ -11,6 +11,13 @@
 		margin-bottom: 1.5em;
 	}
 
+	h1, h2, h3, h4, h5, h6 {
+		font-family: inherit;
+		font-size: 100%;
+		font-style: inherit;
+		font-weight: inherit;
+	}
+
 	h1,
 	.editor-post-title__input {
 		font-family: inherit;


### PR DESCRIPTION
When using dynamic typography, h4 - h6 are bold in the editor.

This adds the same CSS for headings from the frontend into the editor, so those font styles match the frontend of the site.