### PR TITLE
Add the color palette classes to the editor

### DIFF
--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -200,6 +200,16 @@ function generate_do_inline_block_editor_css() {
 				$css->add_property( '--' . $data['slug'], $data['color'] );
 			}
 		}
+
+		foreach ( (array) $global_colors as $key => $data ) {
+			if ( ! empty( $data['slug'] ) && ! empty( $data['color'] ) ) {
+				$css->set_selector( '.has-' . $data['slug'] . '-color' );
+				$css->add_property( 'color', $data['color'] );
+
+				$css->set_selector( '.has-' . $data['slug'] . '-background-color' );
+				$css->add_property( 'background-color', $data['color'] );
+			}
+		}
 	}
 
 	$css->set_selector( 'body .wp-block, html body.gutenberg-editor-page .editor-post-title__block, html body.gutenberg-editor-page .editor-default-block-appender, html body.gutenberg-editor-page .editor-block-list__block' );


### PR DESCRIPTION
This adds the color palette helper classes to the editor.

This fixes a bug where the core "Text color" feature doesn't work when using one of our global colors.

<img width="653" alt="CleanShot 2021-09-10 at 13 00 17@2x" src="https://user-images.githubusercontent.com/20714883/132917094-abae04bd-8a2a-43c1-88b1-a6af333a6122.png">
