### PR TITLE
Make body font selector in the editor more specific

### DIFF
--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -288,7 +288,7 @@ class GeneratePress_Typography {
 		if ( 'editor' === $type ) {
 			switch ( $selector ) {
 				case 'body':
-					$selector = '.editor-styles-wrapper';
+					$selector = 'body .editor-styles-wrapper';
 					break;
 
 				case 'buttons':


### PR DESCRIPTION
This fixes a bug where the `font-family` for the Body element doesn't work in the editor.