### PR TITLE
Add preconnect resource hint to Google fonts

### DIFF
--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -91,7 +91,7 @@ class GeneratePress_Typography {
 				)
 			);
 
-			$google_fonts_uri = add_query_arg( $font_args, '//fonts.googleapis.com/css' );
+			$google_fonts_uri = add_query_arg( $font_args, 'https://fonts.googleapis.com/css' );
 			wp_enqueue_style( 'generate-google-fonts', $google_fonts_uri, array(), GENERATE_VERSION );
 		}
 	}

--- a/inc/general.php
+++ b/inc/general.php
@@ -240,7 +240,9 @@ if ( ! function_exists( 'generate_resource_hints' ) ) {
 	 * @return array $urls           URLs to print for resource hints.
 	 */
 	function generate_resource_hints( $urls, $relation_type ) {
-		if ( wp_style_is( 'generate-fonts', 'queue' ) && 'preconnect' === $relation_type ) {
+		$handle = generate_is_using_dynamic_typography() ? 'generate-google-fonts' : 'generate-fonts';
+
+		if ( wp_style_is( $handle, 'queue' ) && 'preconnect' === $relation_type ) {
 			if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '>=' ) ) {
 				$urls[] = array(
 					'href' => 'https://fonts.gstatic.com',


### PR DESCRIPTION
This adds the preconnect resource hint when using Google fonts in the dynamic typography system.

It also removes the relative protocol from the Google font API request.