### PR TITLE
Use get_the_archive_description()

### DIFF
--- a/inc/structure/archives.php
+++ b/inc/structure/archives.php
@@ -98,14 +98,14 @@ add_action( 'generate_after_archive_title', 'generate_do_archive_description' );
  * @since 2.3
  */
 function generate_do_archive_description() {
-	$term_description = term_description();
+	$term_description = get_the_archive_description();
 
 	if ( ! empty( $term_description ) ) {
-		printf( '<div class="taxonomy-description">%s</div>', $term_description ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	}
-
-	if ( get_the_author_meta( 'description' ) && is_author() ) {
-		echo '<div class="author-info">' . get_the_author_meta( 'description' ) . '</div>';  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		if ( is_author() ) {
+			printf( '<div class="author-info">%s</div>', $term_description ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		} else {
+			printf( '<div class="taxonomy-description">%s</div>', $term_description ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,7 @@ Release date: TBA
 * Tweak: Change sub-menu box-shadow direction when sub-menu opens left
 * Tweak: Replace sub-menu box-shadow with border when opening down
 * Tweak: Remove query loop block margin
+* Tweak: Use get_the_archive_description() instead of term_description()
 * Fix: Missing search form button icon when using font icons
 * Fix: Load comments CSS if comments exists even if new comments are disabled
 * Fix: Sub-menu overlap using dropdown click


### PR DESCRIPTION
Closes https://github.com/tomusborne/generatepress/issues/275

This replaces `term_description()` with `get_the_archive_description()` so users can take advantage of the `get_the_archive_description` filter.