### PR TITLE
Add wp_set_script_translations to Customizer

### DIFF
--- a/inc/customizer/helpers.php
+++ b/inc/customizer/helpers.php
@@ -328,6 +328,10 @@ function generate_do_control_inline_scripts() {
 		true
 	);
 
+	if ( function_exists( 'wp_set_script_translations' ) ) {
+		wp_set_script_translations( 'generate-customizer-controls', 'generatepress' );
+	}
+
 	$color_palette = get_theme_support( 'editor-color-palette' );
 	$colors = array();
 


### PR DESCRIPTION
Closes #319 

This adds the missing `wp_set_script_translations()` function that's required for JS translations to work in our React Customizer controls.

To test, change the language to "Nederlands" and check out the Colors or Typography panels in the Customizer. Without this PR the translations aren't working.