### PR TITLE
Fix align-full alignment in the editor

### DIFF
--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -220,7 +220,7 @@ function generate_do_inline_block_editor_css() {
 		$css->add_property( 'max-width', $content_width_calc );
 	}
 
-	$css->set_selector( 'html body.gutenberg-editor-page .block-editor-block-list__block[data-align="full"]' );
+	$css->set_selector( 'body .wp-block[data-align="full"]' );
 	$css->add_property( 'max-width', 'none' );
 
 	$css->set_selector( '.wp-block[data-align="wide"]' );

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,8 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 
 Release date: TBA
 
+* Fix: Align-full alignment in the editor
+
 = 3.1.1 =
 
 Release date: January 17, 2022


### PR DESCRIPTION
The align-full option causes misalignment in the editor when using WP 5.9: https://www.screencast.com/t/tqzwAn89Yvi

This fixes the CSS selector so it works as it should: https://www.screencast.com/t/NGcExirW

We should double-check that this fix doesn't mess up the alignment in 5.8.3.