### PR TITLE
Fix editor block width selector

### DIFF
--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -212,7 +212,7 @@ function generate_do_inline_block_editor_css() {
 		}
 	}
 
-	$css->set_selector( '.editor-styles-wrapper .wp-block, html body.gutenberg-editor-page .editor-post-title__block, html body.gutenberg-editor-page .editor-default-block-appender, html body.gutenberg-editor-page .editor-block-list__block' );
+	$css->set_selector( 'body .wp-block, html body.gutenberg-editor-page .editor-post-title__block, html body.gutenberg-editor-page .editor-default-block-appender, html body.gutenberg-editor-page .editor-block-list__block' );
 
 	if ( 'true' === get_post_meta( get_the_ID(), '_generate-full-width-content', true ) ) {
 		$css->add_property( 'max-width', '100%' );

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,8 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 
 Release date: TBA
 
+* Fix: Adjust editor block width selector to fix compatibility with GP Premium
+
 = 3.1.2 =
 
 Release date: January 31, 2022


### PR DESCRIPTION
This reverts a change made in 3.1.2: https://github.com/tomusborne/generatepress/pull/339/commits/9c3737f2ea5d103223a7e50d50e0c019ec1a9171#diff-52a76f130932dd212463a7c69442cbc4b4b9ec2e7e05c70730faf7c89a78e375R215

This change is causing issues in GP Premium:
https://generatepress.com/forums/topic/block-editor-width/#post-2101995
https://generatepress.com/forums/topic/wordpress-editor-has-changed-and-everything-is-too-narrow/#post-2102010

This particular change was unnecessary, as it wasn't causing any issues.