### PR TITLE
Fix missing editor CSS

### DIFF
--- a/assets/css/admin/block-editor.css
+++ b/assets/css/admin/block-editor.css
@@ -69,11 +69,6 @@ body .block-editor-block-list__block hr {
 	width: auto;
 }
 
-body .block-editor-block-list__block,
-body .block-editor-block-list__block p {
-	font-size: inherit;
-}
-
 body .block-editor-default-block-appender input[type=text].editor-default-block-appender__content,
 body .block-editor-default-block-appender textarea.editor-default-block-appender__content {
 	font-family: inherit;

--- a/assets/css/admin/block-editor.css
+++ b/assets/css/admin/block-editor.css
@@ -14,7 +14,7 @@
 	color: inherit; /* editor only */
 }
 
-.block-editor-block-list__block blockquote {
+body .block-editor-block-list__block blockquote {
 	border-left: 5px solid rgba(0, 0, 0, 0.05);
 	padding: 20px;
 	font-size: 1.2em;
@@ -24,12 +24,12 @@
 	color: inherit; /* editor only */
 }
 
-.wp-block-quote:not(.is-large):not(.is-style-large) {
+body .wp-block-quote:not(.is-large):not(.is-style-large) {
 	border-left: 5px solid rgba(0, 0, 0, 0.05);
 	padding: 20px;
 }
 
-.block-editor-block-list__block blockquote p:last-child {
+body .block-editor-block-list__block blockquote p:last-child {
 	margin: 0;
 }
 
@@ -39,7 +39,7 @@
 	border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-.block-editor-block-list__block table {
+body .block-editor-block-list__block table {
 	border-collapse: separate;
 	border-spacing: 0;
 	border-width: 1px 0 0 1px;
@@ -60,7 +60,7 @@
 	border-width: 0 1px 1px 0;
 }
 
-.block-editor-block-list__block hr {
+body .block-editor-block-list__block hr {
 	background-color: rgba(0, 0, 0, 0.1);
 	border: 0;
 	height: 1px;
@@ -69,13 +69,13 @@
 	width: auto;
 }
 
-.block-editor-block-list__block,
-.block-editor-block-list__block p {
+body .block-editor-block-list__block,
+body .block-editor-block-list__block p {
 	font-size: inherit;
 }
 
-.block-editor-default-block-appender input[type=text].editor-default-block-appender__content,
-.block-editor-default-block-appender textarea.editor-default-block-appender__content {
+body .block-editor-default-block-appender input[type=text].editor-default-block-appender__content,
+body .block-editor-default-block-appender textarea.editor-default-block-appender__content {
 	font-family: inherit;
 	font-size: inherit;
 }

--- a/assets/css/admin/block-editor.css
+++ b/assets/css/admin/block-editor.css
@@ -14,7 +14,7 @@
 	color: inherit; /* editor only */
 }
 
-body .block-editor-block-list__block blockquote {
+.block-editor-block-list__block blockquote {
 	border-left: 5px solid rgba(0, 0, 0, 0.05);
 	padding: 20px;
 	font-size: 1.2em;
@@ -24,12 +24,12 @@ body .block-editor-block-list__block blockquote {
 	color: inherit; /* editor only */
 }
 
-body .wp-block-quote:not(.is-large):not(.is-style-large) {
+.wp-block-quote:not(.is-large):not(.is-style-large) {
 	border-left: 5px solid rgba(0, 0, 0, 0.05);
 	padding: 20px;
 }
 
-body .block-editor-block-list__block blockquote p:last-child {
+.block-editor-block-list__block blockquote p:last-child {
 	margin: 0;
 }
 
@@ -39,7 +39,7 @@ body .block-editor-block-list__block blockquote p:last-child {
 	border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-body .block-editor-block-list__block table {
+.block-editor-block-list__block table {
 	border-collapse: separate;
 	border-spacing: 0;
 	border-width: 1px 0 0 1px;
@@ -60,7 +60,7 @@ body .block-editor-block-list__block table {
 	border-width: 0 1px 1px 0;
 }
 
-body .block-editor-block-list__block hr {
+.block-editor-block-list__block hr {
 	background-color: rgba(0, 0, 0, 0.1);
 	border: 0;
 	height: 1px;
@@ -69,13 +69,13 @@ body .block-editor-block-list__block hr {
 	width: auto;
 }
 
-body .block-editor-block-list__block,
-body .block-editor-block-list__block p {
+.block-editor-block-list__block,
+.block-editor-block-list__block p {
 	font-size: inherit;
 }
 
-body .block-editor-default-block-appender input[type=text].editor-default-block-appender__content,
-body .block-editor-default-block-appender textarea.editor-default-block-appender__content {
+.block-editor-default-block-appender input[type=text].editor-default-block-appender__content,
+.block-editor-default-block-appender textarea.editor-default-block-appender__content {
 	font-family: inherit;
 	font-size: inherit;
 }

--- a/assets/css/admin/editor-typography.css
+++ b/assets/css/admin/editor-typography.css
@@ -8,6 +8,7 @@ body {
 
 p {
 	line-height: inherit;
+	font-size: inherit;
 	margin-top: 0;
 	margin-bottom: 1.5em;
 }

--- a/assets/css/admin/editor-typography.css
+++ b/assets/css/admin/editor-typography.css
@@ -1,4 +1,4 @@
-html .editor-styles-wrapper {
+body {
 	font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 	font-weight: normal;
 	text-transform: none;
@@ -6,21 +6,21 @@ html .editor-styles-wrapper {
 	line-height: 1.5;
 }
 
-html .editor-styles-wrapper p {
+p {
 	line-height: inherit;
 	margin-top: 0;
 	margin-bottom: 1.5em;
 }
 
-.editor-styles-wrapper h1, .editor-styles-wrapper h2, .editor-styles-wrapper h3, .editor-styles-wrapper h4, .editor-styles-wrapper h5, .editor-styles-wrapper h6 {
+h1, h2, h3, h4, h5, h6 {
 	font-family: inherit;
 	font-size: 100%;
 	font-style: inherit;
 	font-weight: inherit;
 }
 
-.editor-styles-wrapper h1,
-.editor-styles-wrapper .editor-post-title__input {
+h1,
+.editor-post-title__input {
 	font-family: inherit;
 	font-size: 42px;
 	margin-bottom: 20px;
@@ -30,7 +30,7 @@ html .editor-styles-wrapper p {
 	text-transform: none;
 }
 
-.editor-styles-wrapper h2 {
+h2 {
 	font-family: inherit;
 	font-size: 35px;
 	margin-bottom: 20px;
@@ -40,7 +40,7 @@ html .editor-styles-wrapper p {
 	text-transform: none;
 }
 
-.editor-styles-wrapper h3 {
+h3 {
 	font-family: inherit;
 	font-size: 29px;
 	margin-bottom: 20px;
@@ -50,17 +50,17 @@ html .editor-styles-wrapper p {
 	text-transform: none;
 }
 
-.editor-styles-wrapper h4 {
+h4 {
 	font-size: 24px;
 }
 
-.editor-styles-wrapper h5 {
+h5 {
 	font-size: 20px;
 }
 
-.editor-styles-wrapper h4,
-.editor-styles-wrapper h5,
-.editor-styles-wrapper h6 {
+h4,
+h5,
+h6 {
 	font-family: inherit;
 	margin-bottom: 20px;
 	margin-top: 0;

--- a/assets/css/admin/editor-typography.css
+++ b/assets/css/admin/editor-typography.css
@@ -6,21 +6,21 @@ body {
 	line-height: 1.5;
 }
 
-p {
-	line-height: inherit;
+body p {
+	line-height: 1.5;
 	margin-top: 0;
 	margin-bottom: 1.5em;
 }
 
-h1, h2, h3, h4, h5, h6 {
+body h1, body h2, body h3, body h4, body h5, body h6 {
 	font-family: inherit;
 	font-size: 100%;
 	font-style: inherit;
 	font-weight: inherit;
 }
 
-h1,
-.editor-post-title__input {
+body h1,
+body .editor-post-title__input {
 	font-family: inherit;
 	font-size: 42px;
 	margin-bottom: 20px;
@@ -30,7 +30,7 @@ h1,
 	text-transform: none;
 }
 
-h2 {
+body h2 {
 	font-family: inherit;
 	font-size: 35px;
 	margin-bottom: 20px;
@@ -40,7 +40,7 @@ h2 {
 	text-transform: none;
 }
 
-h3 {
+body h3 {
 	font-family: inherit;
 	font-size: 29px;
 	margin-bottom: 20px;
@@ -50,17 +50,17 @@ h3 {
 	text-transform: none;
 }
 
-h4 {
+body h4 {
 	font-size: 24px;
 }
 
-h5 {
+body h5 {
 	font-size: 20px;
 }
 
-h4,
-h5,
-h6 {
+body h4,
+body h5,
+body h6 {
 	font-family: inherit;
 	margin-bottom: 20px;
 	margin-top: 0;

--- a/assets/css/admin/editor-typography.css
+++ b/assets/css/admin/editor-typography.css
@@ -7,7 +7,7 @@ body {
 }
 
 p {
-	line-height: 1.5;
+	line-height: inherit;
 	margin-top: 0;
 	margin-bottom: 1.5em;
 }

--- a/assets/css/admin/editor-typography.css
+++ b/assets/css/admin/editor-typography.css
@@ -6,21 +6,21 @@ body {
 	line-height: 1.5;
 }
 
-body p {
+p {
 	line-height: 1.5;
 	margin-top: 0;
 	margin-bottom: 1.5em;
 }
 
-body h1, body h2, body h3, body h4, body h5, body h6 {
+h1, h2, h3, h4, h5, h6 {
 	font-family: inherit;
 	font-size: 100%;
 	font-style: inherit;
 	font-weight: inherit;
 }
 
-body h1,
-body .editor-post-title__input {
+h1,
+.editor-post-title__input {
 	font-family: inherit;
 	font-size: 42px;
 	margin-bottom: 20px;
@@ -30,7 +30,7 @@ body .editor-post-title__input {
 	text-transform: none;
 }
 
-body h2 {
+h2 {
 	font-family: inherit;
 	font-size: 35px;
 	margin-bottom: 20px;
@@ -40,7 +40,7 @@ body h2 {
 	text-transform: none;
 }
 
-body h3 {
+h3 {
 	font-family: inherit;
 	font-size: 29px;
 	margin-bottom: 20px;
@@ -50,17 +50,17 @@ body h3 {
 	text-transform: none;
 }
 
-body h4 {
+h4 {
 	font-size: 24px;
 }
 
-body h5 {
+h5 {
 	font-size: 20px;
 }
 
-body h4,
-body h5,
-body h6 {
+h4,
+h5,
+h6 {
 	font-family: inherit;
 	margin-bottom: 20px;
 	margin-top: 0;

--- a/assets/css/admin/editor-typography.css
+++ b/assets/css/admin/editor-typography.css
@@ -1,4 +1,4 @@
-.editor-styles-wrapper {
+html .editor-styles-wrapper {
 	font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 	font-weight: normal;
 	text-transform: none;
@@ -6,8 +6,8 @@
 	line-height: 1.5;
 }
 
-.editor-styles-wrapper p {
-	line-height: 1.5;
+html .editor-styles-wrapper p {
+	line-height: inherit;
 	margin-top: 0;
 	margin-bottom: 1.5em;
 }

--- a/functions.php
+++ b/functions.php
@@ -68,8 +68,17 @@ if ( ! function_exists( 'generate_setup' ) ) {
 			$content_width = 1200; /* pixels */
 		}
 
-		// This theme styles the visual editor to resemble the theme style.
-		add_editor_style( 'assets/css/admin/editor-style.css' );
+		// Add editor styles to the block editor.
+		add_theme_support( 'editor-styles' );
+
+		$editor_styles = apply_filters(
+			'generate_editor_styles',
+			array(
+				'assets/css/admin/block-editor.css',
+			)
+		);
+
+		add_editor_style( $editor_styles );
 	}
 }
 

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -281,7 +281,7 @@ function generate_do_inline_block_editor_css() {
 		$buttons_family = generate_get_font_family_css( 'font_buttons', 'generate_settings', generate_get_default_fonts() );
 	}
 
-	$css->set_selector( 'body.gutenberg-editor-page .block-editor-block-list__block, .editor-styles-wrapper' );
+	$css->set_selector( 'body.gutenberg-editor-page .block-editor-block-list__block, html .editor-styles-wrapper' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', $body_family );
@@ -303,15 +303,15 @@ function generate_do_inline_block_editor_css() {
 	}
 
 	if ( ! generate_is_using_dynamic_typography() ) {
-		$css->set_selector( '.editor-styles-wrapper, .editor-styles-wrapper p, .editor-styles-wrapper .mce-content-body' );
+		$css->set_selector( 'html .editor-styles-wrapper, html .editor-styles-wrapper p, html .editor-styles-wrapper .mce-content-body' );
 		$css->add_property( 'line-height', floatval( $font_settings['body_line_height'] ) );
 
-		$css->set_selector( '.editor-styles-wrapper p' );
+		$css->set_selector( 'html .editor-styles-wrapper p' );
 		$css->add_property( 'margin-top', '0px' );
 		$css->add_property( 'margin-bottom', $font_settings['paragraph_margin'], false, 'em' );
 	}
 
-	$css->set_selector( '.editor-styles-wrapper h1, .wp-block-heading h1.editor-rich-text__tinymce, .editor-styles-wrapper .editor-post-title__input' );
+	$css->set_selector( 'html .editor-styles-wrapper h1, .wp-block-heading h1.editor-rich-text__tinymce, .editor-styles-wrapper .editor-post-title__input' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', 'inherit' === $h1_family || '' === $h1_family ? $body_family : $h1_family );
@@ -336,7 +336,7 @@ function generate_do_inline_block_editor_css() {
 		$css->add_property( 'color', $color_settings['content_title_color'] );
 	}
 
-	$css->set_selector( '.editor-styles-wrapper h2, .wp-block-heading h2.editor-rich-text__tinymce' );
+	$css->set_selector( 'html .editor-styles-wrapper h2, .wp-block-heading h2.editor-rich-text__tinymce' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', $h2_family );
@@ -356,7 +356,7 @@ function generate_do_inline_block_editor_css() {
 		$css->add_property( 'color', generate_get_option( 'text_color' ) );
 	}
 
-	$css->set_selector( '.editor-styles-wrapper h3, .wp-block-heading h3.editor-rich-text__tinymce' );
+	$css->set_selector( 'html .editor-styles-wrapper h3, .wp-block-heading h3.editor-rich-text__tinymce' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', $h3_family );
@@ -376,7 +376,7 @@ function generate_do_inline_block_editor_css() {
 		$css->add_property( 'color', generate_get_option( 'text_color' ) );
 	}
 
-	$css->set_selector( '.editor-styles-wrapper h4, .wp-block-heading h4.editor-rich-text__tinymce' );
+	$css->set_selector( 'html .editor-styles-wrapper h4, .wp-block-heading h4.editor-rich-text__tinymce' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', $h4_family );
@@ -404,7 +404,7 @@ function generate_do_inline_block_editor_css() {
 		$css->add_property( 'color', generate_get_option( 'text_color' ) );
 	}
 
-	$css->set_selector( '.editor-styles-wrapper h5, .wp-block-heading h5.editor-rich-text__tinymce' );
+	$css->set_selector( 'html .editor-styles-wrapper h5, .wp-block-heading h5.editor-rich-text__tinymce' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', $h5_family );
@@ -432,7 +432,7 @@ function generate_do_inline_block_editor_css() {
 		$css->add_property( 'color', generate_get_option( 'text_color' ) );
 	}
 
-	$css->set_selector( '.editor-styles-wrapper h6, .wp-block-heading h6.editor-rich-text__tinymce' );
+	$css->set_selector( 'html .editor-styles-wrapper h6, .wp-block-heading h6.editor-rich-text__tinymce' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', $h6_family );

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -100,18 +100,16 @@ add_action( 'enqueue_block_editor_assets', 'generate_enqueue_backend_block_edito
  * @since 2.2
  */
 function generate_enqueue_backend_block_editor_assets() {
-	wp_enqueue_style( 'generate-block-editor-styles', get_template_directory_uri() . '/assets/css/admin/block-editor.css', false, GENERATE_VERSION, 'all' );
 	wp_enqueue_script( 'generate-block-editor-tinycolor', get_template_directory_uri() . '/assets/js/admin/tinycolor.js', false, GENERATE_VERSION, true );
 	wp_enqueue_script( 'generate-block-editor-scripts', get_template_directory_uri() . '/assets/js/admin/block-editor.js', array( 'jquery', 'generate-block-editor-tinycolor' ), GENERATE_VERSION, true );
 
 	$show_editor_styles = apply_filters( 'generate_show_block_editor_styles', true );
 
 	if ( $show_editor_styles ) {
-		wp_add_inline_style( 'generate-block-editor-styles', wp_strip_all_tags( generate_do_inline_block_editor_css() ) );
+		wp_add_inline_style( 'wp-edit-blocks', wp_strip_all_tags( generate_do_inline_block_editor_css() ) );
 
 		if ( generate_is_using_dynamic_typography() ) {
-			wp_enqueue_style( 'generate-editor-typography', get_template_directory_uri() . '/assets/css/admin/editor-typography.css', false, GENERATE_VERSION, 'all' );
-			wp_add_inline_style( 'generate-editor-typography', wp_strip_all_tags( GeneratePress_Typography::get_css( 'core', 'editor' ) ) );
+			wp_add_inline_style( 'wp-edit-blocks', wp_strip_all_tags( GeneratePress_Typography::get_css( 'core', 'editor' ) ) );
 		}
 	}
 

--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -37,6 +37,7 @@ class GeneratePress_Typography {
 	public function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_google_fonts' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_google_fonts' ) );
+		add_filter( 'generate_editor_styles', array( $this, 'add_editor_styles' ) );
 	}
 
 	/**
@@ -354,6 +355,19 @@ class GeneratePress_Typography {
 			'marginBottomMobile' => '',
 			'marginBottomUnit' => 'px',
 		);
+	}
+
+	/**
+	 * Add editor styles to the block editor.
+	 *
+	 * @param array $editor_styles Existing styles.
+	 */
+	public function add_editor_styles( $editor_styles ) {
+		if ( generate_is_using_dynamic_typography() ) {
+			$editor_styles[] = 'assets/css/admin/editor-typography.css';
+		}
+
+		return $editor_styles;
 	}
 }
 

--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -118,14 +118,10 @@ class GeneratePress_Typography {
 
 			$body_selector = 'body';
 			$paragraph_selector = 'p';
-			$tablet_prefix = '';
-			$mobile_prefix = '';
 
 			if ( 'editor' === $type ) {
 				$body_selector = '.editor-styles-wrapper';
 				$paragraph_selector = '.editor-styles-wrapper p';
-				$tablet_prefix = '.gp-is-device-tablet ';
-				$mobile_prefix = '.gp-is-device-mobile ';
 			}
 
 			foreach ( $typography as $key => $data ) {
@@ -160,16 +156,7 @@ class GeneratePress_Typography {
 					$css->add_property( 'margin-bottom', $options['marginBottom'], false, $options['marginBottomUnit'] );
 				}
 
-				if ( 'frontend' === $type ) {
-					$css->start_media_query( generate_get_media_query( 'tablet' ) );
-				}
-
-				if ( 'editor' === $type ) {
-					// Add the tablet prefix to each class.
-					$selector = explode( ', ', $selector );
-					$selector = preg_filter( '/^/', $tablet_prefix, $selector );
-					$selector = implode( ', ', $selector );
-				}
+				$css->start_media_query( generate_get_media_query( 'tablet' ) );
 
 				$css->set_selector( $selector );
 				$css->add_property( 'font-size', $options['fontSizeTablet'], false, $options['fontSizeUnit'] );
@@ -179,24 +166,16 @@ class GeneratePress_Typography {
 					$css->add_property( 'line-height', $options['lineHeightTablet'], false, $options['lineHeightUnit'] );
 					$css->add_property( 'margin-bottom', $options['marginBottomTablet'], false, $options['marginBottomUnit'] );
 				} else {
-					$css->set_selector( $tablet_prefix . $body_selector );
+					$css->set_selector( $body_selector );
 					$css->add_property( 'line-height', $options['lineHeightTablet'], false, $options['lineHeightUnit'] );
 
-					$css->set_selector( $tablet_prefix . $paragraph_selector );
+					$css->set_selector( $paragraph_selector );
 					$css->add_property( 'margin-bottom', $options['marginBottomTablet'], false, $options['marginBottomUnit'] );
 				}
 
-				if ( 'frontend' === $type ) {
-					$css->stop_media_query();
-				}
+				$css->stop_media_query();
 
-				if ( 'frontend' === $type ) {
-					$css->start_media_query( generate_get_media_query( 'mobile' ) );
-				}
-
-				if ( 'editor' === $type ) {
-					$selector = str_replace( '.gp-is-device-tablet', '.gp-is-device-mobile', $selector );
-				}
+				$css->start_media_query( generate_get_media_query( 'mobile' ) );
 
 				$css->set_selector( $selector );
 				$css->add_property( 'font-size', $options['fontSizeMobile'], false, $options['fontSizeUnit'] );
@@ -206,16 +185,14 @@ class GeneratePress_Typography {
 					$css->add_property( 'line-height', $options['lineHeightMobile'], false, $options['lineHeightUnit'] );
 					$css->add_property( 'margin-bottom', $options['marginBottomMobile'], false, $options['marginBottomUnit'] );
 				} else {
-					$css->set_selector( $mobile_prefix . $body_selector );
+					$css->set_selector( $body_selector );
 					$css->add_property( 'line-height', $options['lineHeightMobile'], false, $options['lineHeightUnit'] );
 
-					$css->set_selector( $mobile_prefix . $paragraph_selector );
+					$css->set_selector( $paragraph_selector );
 					$css->add_property( 'margin-bottom', $options['marginBottomMobile'], false, $options['marginBottomUnit'] );
 				}
 
-				if ( 'frontend' === $type ) {
-					$css->stop_media_query();
-				}
+				$css->stop_media_query();
 			}
 
 			return $css->css_output();

--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -120,8 +120,8 @@ class GeneratePress_Typography {
 			$paragraph_selector = 'p';
 
 			if ( 'editor' === $type ) {
-				$body_selector = '.editor-styles-wrapper';
-				$paragraph_selector = '.editor-styles-wrapper p';
+				$body_selector = 'html .editor-styles-wrapper';
+				$paragraph_selector = 'html .editor-styles-wrapper p';
 			}
 
 			foreach ( $typography as $key => $data ) {

--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -288,7 +288,7 @@ class GeneratePress_Typography {
 		if ( 'editor' === $type ) {
 			switch ( $selector ) {
 				case 'body':
-					$selector = 'body .editor-styles-wrapper';
+					$selector = 'html .editor-styles-wrapper';
 					break;
 
 				case 'buttons':

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 Release date: TBA
 
 * Fix: Adjust editor block width selector to fix compatibility with GP Premium
+* Fix: Typography selectors in the editor
 
 = 3.1.2 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Release date: TBA
 
 * Fix: Adjust editor block width selector to fix compatibility with GP Premium
 * Fix: Typography selectors in the editor
+* Fix: Google Fonts API request in the editor when viewing tablet or mobile
 
 = 3.1.2 =
 

--- a/sass/editor-typography.scss
+++ b/sass/editor-typography.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper {
+body {
 	font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 	font-weight: normal;
 	text-transform: none;

--- a/sass/editor-typography.scss
+++ b/sass/editor-typography.scss
@@ -4,64 +4,64 @@ body {
 	text-transform: none;
 	font-size: 17px;
 	line-height: 1.5;
+}
 
-	p {
-		line-height: 1.5;
-		margin-top: 0;
-		margin-bottom: 1.5em;
-	}
+p {
+	line-height: 1.5;
+	margin-top: 0;
+	margin-bottom: 1.5em;
+}
 
-	h1, h2, h3, h4, h5, h6 {
-		font-family: inherit;
-		font-size: 100%;
-		font-style: inherit;
-		font-weight: inherit;
-	}
+h1, h2, h3, h4, h5, h6 {
+	font-family: inherit;
+	font-size: 100%;
+	font-style: inherit;
+	font-weight: inherit;
+}
 
-	h1,
-	.editor-post-title__input {
-		font-family: inherit;
-		font-size: 42px;
-		margin-bottom: 20px;
-		margin-top: 0;
-		line-height: 1.2em;
-		font-weight: normal;
-		text-transform: none;
-	}
+h1,
+.editor-post-title__input {
+	font-family: inherit;
+	font-size: 42px;
+	margin-bottom: 20px;
+	margin-top: 0;
+	line-height: 1.2em;
+	font-weight: normal;
+	text-transform: none;
+}
 
-	h2 {
-		font-family: inherit;
-		font-size: 35px;
-		margin-bottom: 20px;
-		margin-top: 0;
-		line-height: 1.2em;
-		font-weight: normal;
-		text-transform: none;
-	}
+h2 {
+	font-family: inherit;
+	font-size: 35px;
+	margin-bottom: 20px;
+	margin-top: 0;
+	line-height: 1.2em;
+	font-weight: normal;
+	text-transform: none;
+}
 
-	h3 {
-		font-family: inherit;
-		font-size: 29px;
-		margin-bottom: 20px;
-		margin-top: 0;
-		line-height: 1.2em;
-		font-weight: normal;
-		text-transform: none;
-	}
+h3 {
+	font-family: inherit;
+	font-size: 29px;
+	margin-bottom: 20px;
+	margin-top: 0;
+	line-height: 1.2em;
+	font-weight: normal;
+	text-transform: none;
+}
 
-	h4 {
-		font-size: 24px;
-	}
+h4 {
+	font-size: 24px;
+}
 
-	h5 {
-		font-size: 20px;
-	}
+h5 {
+	font-size: 20px;
+}
 
-	h4,
-	h5,
-	h6 {
-		font-family: inherit;
-		margin-bottom: 20px;
-		margin-top: 0;
-	}
+h4,
+h5,
+h6 {
+	font-family: inherit;
+	margin-bottom: 20px;
+	margin-top: 0;
 }

--- a/sass/editor-typography.scss
+++ b/sass/editor-typography.scss
@@ -7,7 +7,7 @@ body {
 }
 
 p {
-	line-height: 1.5;
+	line-height: inherit;
 	margin-top: 0;
 	margin-bottom: 1.5em;
 }


### PR DESCRIPTION
This PR fixes missing styles in WordPress 5.9 when viewing the tablet or mobile modes.

What we're doing:

1. Using `add_editor_style()` to add our static stylesheets. This ensures that WP adds these files to the responsive iframe.
2. Attach our `wp_add_inline_style()` functions to the `wp-edit-blocks` handle, as this file is added to the iframes as well. This is a workaround as it's currently not possible for themes to add dynamic CSS that will also appear in the iframes.