### PR TITLE
Fix responsive google fonts request

### DIFF
--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -111,6 +111,18 @@ function generate_enqueue_backend_block_editor_assets() {
 
 		if ( generate_is_using_dynamic_typography() ) {
 			wp_enqueue_style( 'generate-editor-typography', get_template_directory_uri() . '/assets/css/admin/editor-typography.css', false, GENERATE_VERSION, 'all' );
+
+			$google_fonts_uri = GeneratePress_Typography::get_google_fonts_uri();
+
+			if ( $google_fonts_uri ) {
+				$google_fonts_import = sprintf(
+					'@import "%s";',
+					$google_fonts_uri
+				);
+
+				wp_add_inline_style( 'generate-editor-typography', $google_fonts_import );
+			}
+
 			wp_add_inline_style( 'generate-editor-typography', wp_strip_all_tags( GeneratePress_Typography::get_css( 'core', 'editor' ) ) );
 		}
 	}

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -135,11 +135,11 @@ function generate_enqueue_backend_block_editor_assets() {
 
 	if ( $show_editor_styles ) {
 		// Using wp-edit-blocks for now until we do this: https://github.com/tomusborne/generatepress/pull/343.
+		wp_add_inline_style( 'wp-edit-blocks', wp_strip_all_tags( generate_do_inline_block_editor_css() ) );
+
 		if ( generate_is_using_dynamic_typography() ) {
 			wp_add_inline_style( 'wp-edit-blocks', wp_strip_all_tags( GeneratePress_Typography::get_css( 'core', 'editor' ) ) );
 		}
-
-		wp_add_inline_style( 'wp-edit-blocks', wp_strip_all_tags( generate_do_inline_block_editor_css() ) );
 	}
 
 	wp_enqueue_script(

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -92,6 +92,34 @@ function generate_get_block_editor_content_width() {
 	return apply_filters( 'generate_block_editor_content_width', $content_width );
 }
 
+add_filter( 'block_editor_settings_all', 'generate_add_inline_block_editor_styles' );
+/**
+ * Add dynamic inline styles to the block editor content.
+ *
+ * @param array $editor_settings The existing editor settings.
+ */
+function generate_add_inline_block_editor_styles( $editor_settings ) {
+	$show_editor_styles = apply_filters( 'generate_show_block_editor_styles', true );
+
+	if ( $show_editor_styles ) {
+		if ( generate_is_using_dynamic_typography() ) {
+			$google_fonts_uri = GeneratePress_Typography::get_google_fonts_uri();
+
+			if ( $google_fonts_uri ) {
+				// Need to use @import for now until this is ready: https://github.com/WordPress/gutenberg/pull/35950.
+				$google_fonts_import = sprintf(
+					'@import "%s";',
+					$google_fonts_uri
+				);
+
+				$editor_settings['styles'][] = array( 'css' => $google_fonts_import );
+			}
+		}
+	}
+
+	return $editor_settings;
+}
+
 add_action( 'enqueue_block_editor_assets', 'generate_enqueue_google_fonts' );
 add_action( 'enqueue_block_editor_assets', 'generate_enqueue_backend_block_editor_assets' );
 /**
@@ -106,22 +134,12 @@ function generate_enqueue_backend_block_editor_assets() {
 	$show_editor_styles = apply_filters( 'generate_show_block_editor_styles', true );
 
 	if ( $show_editor_styles ) {
-		wp_add_inline_style( 'wp-edit-blocks', wp_strip_all_tags( generate_do_inline_block_editor_css() ) );
-
+		// Using wp-edit-blocks for now until we do this: https://github.com/tomusborne/generatepress/pull/343.
 		if ( generate_is_using_dynamic_typography() ) {
-			$google_fonts_uri = GeneratePress_Typography::get_google_fonts_uri();
-
-			if ( $google_fonts_uri ) {
-				$google_fonts_import = sprintf(
-					'@import "%s";',
-					$google_fonts_uri
-				);
-
-				wp_add_inline_style( 'wp-edit-blocks', $google_fonts_import );
-			}
-
 			wp_add_inline_style( 'wp-edit-blocks', wp_strip_all_tags( GeneratePress_Typography::get_css( 'core', 'editor' ) ) );
 		}
+
+		wp_add_inline_style( 'wp-edit-blocks', wp_strip_all_tags( generate_do_inline_block_editor_css() ) );
 	}
 
 	wp_enqueue_script(

--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -40,19 +40,16 @@ class GeneratePress_Typography {
 	}
 
 	/**
-	 * Enqueue Google Fonts if they're set.
+	 * Generate our Google Fonts URI.
 	 */
-	public function enqueue_google_fonts() {
-		if ( ! generate_is_using_dynamic_typography() ) {
-			return;
-		}
-
+	public static function get_google_fonts_uri() {
 		$fonts = generate_get_option( 'font_manager' );
 
 		if ( empty( $fonts ) ) {
 			return;
 		}
 
+		$google_fonts_uri = '';
 		$data = array();
 
 		foreach ( $fonts as $font ) {
@@ -92,6 +89,22 @@ class GeneratePress_Typography {
 			);
 
 			$google_fonts_uri = add_query_arg( $font_args, 'https://fonts.googleapis.com/css' );
+		}
+
+		return $google_fonts_uri;
+	}
+
+	/**
+	 * Enqueue Google Fonts if they're set.
+	 */
+	public function enqueue_google_fonts() {
+		if ( ! generate_is_using_dynamic_typography() ) {
+			return;
+		}
+
+		$google_fonts_uri = self::get_google_fonts_uri();
+
+		if ( $google_fonts_uri ) {
 			wp_enqueue_style( 'generate-google-fonts', $google_fonts_uri, array(), GENERATE_VERSION );
 		}
 	}

--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -36,7 +36,6 @@ class GeneratePress_Typography {
 	 */
 	public function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_google_fonts' ) );
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_google_fonts' ) );
 	}
 
 	/**


### PR DESCRIPTION
This fixes a bug where the Google fonts API request wasn't being added inside the responsive iframe in the editor.

Instead, this method uses `@import` to import the fonts using `wp_add_inline_style()` for our typography stylesheet. This stylesheet and its inline styles are added to the responsive iframe.