### PR TITLE
Release 3.1.3

### DIFF
--- a/assets/css/admin/block-editor.css
+++ b/assets/css/admin/block-editor.css
@@ -69,11 +69,6 @@ body .block-editor-block-list__block hr {
 	width: auto;
 }
 
-body .block-editor-block-list__block,
-body .block-editor-block-list__block p {
-	font-size: inherit;
-}
-
 body .block-editor-default-block-appender input[type=text].editor-default-block-appender__content,
 body .block-editor-default-block-appender textarea.editor-default-block-appender__content {
 	font-family: inherit;

--- a/assets/css/admin/editor-typography.css
+++ b/assets/css/admin/editor-typography.css
@@ -1,4 +1,4 @@
-.editor-styles-wrapper {
+body {
 	font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 	font-weight: normal;
 	text-transform: none;
@@ -6,21 +6,22 @@
 	line-height: 1.5;
 }
 
-.editor-styles-wrapper p {
-	line-height: 1.5;
+p {
+	line-height: inherit;
+	font-size: inherit;
 	margin-top: 0;
 	margin-bottom: 1.5em;
 }
 
-.editor-styles-wrapper h1, .editor-styles-wrapper h2, .editor-styles-wrapper h3, .editor-styles-wrapper h4, .editor-styles-wrapper h5, .editor-styles-wrapper h6 {
+h1, h2, h3, h4, h5, h6 {
 	font-family: inherit;
 	font-size: 100%;
 	font-style: inherit;
 	font-weight: inherit;
 }
 
-.editor-styles-wrapper h1,
-.editor-styles-wrapper .editor-post-title__input {
+h1,
+.editor-post-title__input {
 	font-family: inherit;
 	font-size: 42px;
 	margin-bottom: 20px;
@@ -30,7 +31,7 @@
 	text-transform: none;
 }
 
-.editor-styles-wrapper h2 {
+h2 {
 	font-family: inherit;
 	font-size: 35px;
 	margin-bottom: 20px;
@@ -40,7 +41,7 @@
 	text-transform: none;
 }
 
-.editor-styles-wrapper h3 {
+h3 {
 	font-family: inherit;
 	font-size: 29px;
 	margin-bottom: 20px;
@@ -50,17 +51,17 @@
 	text-transform: none;
 }
 
-.editor-styles-wrapper h4 {
+h4 {
 	font-size: 24px;
 }
 
-.editor-styles-wrapper h5 {
+h5 {
 	font-size: 20px;
 }
 
-.editor-styles-wrapper h4,
-.editor-styles-wrapper h5,
-.editor-styles-wrapper h6 {
+h4,
+h5,
+h6 {
 	font-family: inherit;
 	margin-bottom: 20px;
 	margin-top: 0;

--- a/functions.php
+++ b/functions.php
@@ -68,8 +68,17 @@ if ( ! function_exists( 'generate_setup' ) ) {
 			$content_width = 1200; /* pixels */
 		}
 
-		// This theme styles the visual editor to resemble the theme style.
-		add_editor_style( 'assets/css/admin/editor-style.css' );
+		// Add editor styles to the block editor.
+		add_theme_support( 'editor-styles' );
+
+		$editor_styles = apply_filters(
+			'generate_editor_styles',
+			array(
+				'assets/css/admin/block-editor.css',
+			)
+		);
+
+		add_editor_style( $editor_styles );
 	}
 }
 

--- a/functions.php
+++ b/functions.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Set our theme version.
-define( 'GENERATE_VERSION', '3.1.2' );
+define( 'GENERATE_VERSION', '3.1.3-beta.1' );
 
 if ( ! function_exists( 'generate_setup' ) ) {
 	add_action( 'after_setup_theme', 'generate_setup' );

--- a/functions.php
+++ b/functions.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Set our theme version.
-define( 'GENERATE_VERSION', '3.1.3-beta.1' );
+define( 'GENERATE_VERSION', '3.1.3' );
 
 if ( ! function_exists( 'generate_setup' ) ) {
 	add_action( 'after_setup_theme', 'generate_setup' );

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -92,6 +92,34 @@ function generate_get_block_editor_content_width() {
 	return apply_filters( 'generate_block_editor_content_width', $content_width );
 }
 
+add_filter( 'block_editor_settings_all', 'generate_add_inline_block_editor_styles' );
+/**
+ * Add dynamic inline styles to the block editor content.
+ *
+ * @param array $editor_settings The existing editor settings.
+ */
+function generate_add_inline_block_editor_styles( $editor_settings ) {
+	$show_editor_styles = apply_filters( 'generate_show_block_editor_styles', true );
+
+	if ( $show_editor_styles ) {
+		if ( generate_is_using_dynamic_typography() ) {
+			$google_fonts_uri = GeneratePress_Typography::get_google_fonts_uri();
+
+			if ( $google_fonts_uri ) {
+				// Need to use @import for now until this is ready: https://github.com/WordPress/gutenberg/pull/35950.
+				$google_fonts_import = sprintf(
+					'@import "%s";',
+					$google_fonts_uri
+				);
+
+				$editor_settings['styles'][] = array( 'css' => $google_fonts_import );
+			}
+		}
+	}
+
+	return $editor_settings;
+}
+
 add_action( 'enqueue_block_editor_assets', 'generate_enqueue_google_fonts' );
 add_action( 'enqueue_block_editor_assets', 'generate_enqueue_backend_block_editor_assets' );
 /**
@@ -100,18 +128,17 @@ add_action( 'enqueue_block_editor_assets', 'generate_enqueue_backend_block_edito
  * @since 2.2
  */
 function generate_enqueue_backend_block_editor_assets() {
-	wp_enqueue_style( 'generate-block-editor-styles', get_template_directory_uri() . '/assets/css/admin/block-editor.css', false, GENERATE_VERSION, 'all' );
 	wp_enqueue_script( 'generate-block-editor-tinycolor', get_template_directory_uri() . '/assets/js/admin/tinycolor.js', false, GENERATE_VERSION, true );
 	wp_enqueue_script( 'generate-block-editor-scripts', get_template_directory_uri() . '/assets/js/admin/block-editor.js', array( 'jquery', 'generate-block-editor-tinycolor' ), GENERATE_VERSION, true );
 
 	$show_editor_styles = apply_filters( 'generate_show_block_editor_styles', true );
 
 	if ( $show_editor_styles ) {
-		wp_add_inline_style( 'generate-block-editor-styles', wp_strip_all_tags( generate_do_inline_block_editor_css() ) );
+		// Using wp-edit-blocks for now until we do this: https://github.com/tomusborne/generatepress/pull/343.
+		wp_add_inline_style( 'wp-edit-blocks', wp_strip_all_tags( generate_do_inline_block_editor_css() ) );
 
 		if ( generate_is_using_dynamic_typography() ) {
-			wp_enqueue_style( 'generate-editor-typography', get_template_directory_uri() . '/assets/css/admin/editor-typography.css', false, GENERATE_VERSION, 'all' );
-			wp_add_inline_style( 'generate-editor-typography', wp_strip_all_tags( GeneratePress_Typography::get_css( 'core', 'editor' ) ) );
+			wp_add_inline_style( 'wp-edit-blocks', wp_strip_all_tags( GeneratePress_Typography::get_css( 'core', 'editor' ) ) );
 		}
 	}
 
@@ -281,7 +308,7 @@ function generate_do_inline_block_editor_css() {
 		$buttons_family = generate_get_font_family_css( 'font_buttons', 'generate_settings', generate_get_default_fonts() );
 	}
 
-	$css->set_selector( 'body.gutenberg-editor-page .block-editor-block-list__block, .editor-styles-wrapper' );
+	$css->set_selector( 'body.gutenberg-editor-page .block-editor-block-list__block, html .editor-styles-wrapper' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', $body_family );
@@ -303,15 +330,15 @@ function generate_do_inline_block_editor_css() {
 	}
 
 	if ( ! generate_is_using_dynamic_typography() ) {
-		$css->set_selector( '.editor-styles-wrapper, .editor-styles-wrapper p, .editor-styles-wrapper .mce-content-body' );
+		$css->set_selector( 'html .editor-styles-wrapper, html .editor-styles-wrapper p, html .editor-styles-wrapper .mce-content-body' );
 		$css->add_property( 'line-height', floatval( $font_settings['body_line_height'] ) );
 
-		$css->set_selector( '.editor-styles-wrapper p' );
+		$css->set_selector( 'html .editor-styles-wrapper p' );
 		$css->add_property( 'margin-top', '0px' );
 		$css->add_property( 'margin-bottom', $font_settings['paragraph_margin'], false, 'em' );
 	}
 
-	$css->set_selector( '.editor-styles-wrapper h1, .wp-block-heading h1.editor-rich-text__tinymce, .editor-styles-wrapper .editor-post-title__input' );
+	$css->set_selector( 'html .editor-styles-wrapper h1, .wp-block-heading h1.editor-rich-text__tinymce, .editor-styles-wrapper .editor-post-title__input' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', 'inherit' === $h1_family || '' === $h1_family ? $body_family : $h1_family );
@@ -336,7 +363,7 @@ function generate_do_inline_block_editor_css() {
 		$css->add_property( 'color', $color_settings['content_title_color'] );
 	}
 
-	$css->set_selector( '.editor-styles-wrapper h2, .wp-block-heading h2.editor-rich-text__tinymce' );
+	$css->set_selector( 'html .editor-styles-wrapper h2, .wp-block-heading h2.editor-rich-text__tinymce' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', $h2_family );
@@ -356,7 +383,7 @@ function generate_do_inline_block_editor_css() {
 		$css->add_property( 'color', generate_get_option( 'text_color' ) );
 	}
 
-	$css->set_selector( '.editor-styles-wrapper h3, .wp-block-heading h3.editor-rich-text__tinymce' );
+	$css->set_selector( 'html .editor-styles-wrapper h3, .wp-block-heading h3.editor-rich-text__tinymce' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', $h3_family );
@@ -376,7 +403,7 @@ function generate_do_inline_block_editor_css() {
 		$css->add_property( 'color', generate_get_option( 'text_color' ) );
 	}
 
-	$css->set_selector( '.editor-styles-wrapper h4, .wp-block-heading h4.editor-rich-text__tinymce' );
+	$css->set_selector( 'html .editor-styles-wrapper h4, .wp-block-heading h4.editor-rich-text__tinymce' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', $h4_family );
@@ -404,7 +431,7 @@ function generate_do_inline_block_editor_css() {
 		$css->add_property( 'color', generate_get_option( 'text_color' ) );
 	}
 
-	$css->set_selector( '.editor-styles-wrapper h5, .wp-block-heading h5.editor-rich-text__tinymce' );
+	$css->set_selector( 'html .editor-styles-wrapper h5, .wp-block-heading h5.editor-rich-text__tinymce' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', $h5_family );
@@ -432,7 +459,7 @@ function generate_do_inline_block_editor_css() {
 		$css->add_property( 'color', generate_get_option( 'text_color' ) );
 	}
 
-	$css->set_selector( '.editor-styles-wrapper h6, .wp-block-heading h6.editor-rich-text__tinymce' );
+	$css->set_selector( 'html .editor-styles-wrapper h6, .wp-block-heading h6.editor-rich-text__tinymce' );
 
 	if ( ! generate_is_using_dynamic_typography() ) {
 		$css->add_property( 'font-family', $h6_family );

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -212,7 +212,7 @@ function generate_do_inline_block_editor_css() {
 		}
 	}
 
-	$css->set_selector( '.editor-styles-wrapper .wp-block, html body.gutenberg-editor-page .editor-post-title__block, html body.gutenberg-editor-page .editor-default-block-appender, html body.gutenberg-editor-page .editor-block-list__block' );
+	$css->set_selector( 'body .wp-block, html body.gutenberg-editor-page .editor-post-title__block, html body.gutenberg-editor-page .editor-default-block-appender, html body.gutenberg-editor-page .editor-block-list__block' );
 
 	if ( 'true' === get_post_meta( get_the_ID(), '_generate-full-width-content', true ) ) {
 		$css->add_property( 'max-width', '100%' );

--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -286,15 +286,15 @@ class GeneratePress_Typography {
 					break;
 
 				case 'all-headings':
-					$selector = '.editor-styles-wrapper h1, .editor-styles-wrapper h2, .editor-styles-wrapper h3, .editor-styles-wrapper h4, .editor-styles-wrapper h5, .editor-styles-wrapper h6';
+					$selector = 'html .editor-styles-wrapper h1, html .editor-styles-wrapper h2, html .editor-styles-wrapper h3, html .editor-styles-wrapper h4, html .editor-styles-wrapper h5, html .editor-styles-wrapper h6';
 					break;
 
 				case 'h1':
-					$selector = '.editor-styles-wrapper h1, .editor-styles-wrapper .editor-post-title__input';
+					$selector = 'html .editor-styles-wrapper h1, html .editor-styles-wrapper .editor-post-title__input';
 					break;
 
 				case 'single-content-title':
-					$selector = '.editor-styles-wrapper .editor-post-title__input';
+					$selector = 'html .editor-styles-wrapper .editor-post-title__input';
 					break;
 
 				case 'h2':
@@ -302,7 +302,7 @@ class GeneratePress_Typography {
 				case 'h4':
 				case 'h5':
 				case 'h6':
-					$selector = '.editor-styles-wrapper ' . $selector;
+					$selector = 'html .editor-styles-wrapper ' . $selector;
 					break;
 			}
 		}

--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -37,6 +37,11 @@ class GeneratePress_Typography {
 	public function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_google_fonts' ) );
 		add_filter( 'generate_editor_styles', array( $this, 'add_editor_styles' ) );
+
+		// Load fonts the old way in versions before 5.8 as block_editor_settings_all didn't exist.
+		if ( version_compare( $GLOBALS['wp_version'], '5.8', '<' ) ) {
+			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_google_fonts' ) );
+		}
 	}
 
 	/**

--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -36,23 +36,20 @@ class GeneratePress_Typography {
 	 */
 	public function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_google_fonts' ) );
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_google_fonts' ) );
+		add_filter( 'generate_editor_styles', array( $this, 'add_editor_styles' ) );
 	}
 
 	/**
-	 * Enqueue Google Fonts if they're set.
+	 * Generate our Google Fonts URI.
 	 */
-	public function enqueue_google_fonts() {
-		if ( ! generate_is_using_dynamic_typography() ) {
-			return;
-		}
-
+	public static function get_google_fonts_uri() {
 		$fonts = generate_get_option( 'font_manager' );
 
 		if ( empty( $fonts ) ) {
 			return;
 		}
 
+		$google_fonts_uri = '';
 		$data = array();
 
 		foreach ( $fonts as $font ) {
@@ -92,6 +89,22 @@ class GeneratePress_Typography {
 			);
 
 			$google_fonts_uri = add_query_arg( $font_args, 'https://fonts.googleapis.com/css' );
+		}
+
+		return $google_fonts_uri;
+	}
+
+	/**
+	 * Enqueue Google Fonts if they're set.
+	 */
+	public function enqueue_google_fonts() {
+		if ( ! generate_is_using_dynamic_typography() ) {
+			return;
+		}
+
+		$google_fonts_uri = self::get_google_fonts_uri();
+
+		if ( $google_fonts_uri ) {
 			wp_enqueue_style( 'generate-google-fonts', $google_fonts_uri, array(), GENERATE_VERSION );
 		}
 	}
@@ -118,14 +131,10 @@ class GeneratePress_Typography {
 
 			$body_selector = 'body';
 			$paragraph_selector = 'p';
-			$tablet_prefix = '';
-			$mobile_prefix = '';
 
 			if ( 'editor' === $type ) {
-				$body_selector = '.editor-styles-wrapper';
-				$paragraph_selector = '.editor-styles-wrapper p';
-				$tablet_prefix = '.gp-is-device-tablet ';
-				$mobile_prefix = '.gp-is-device-mobile ';
+				$body_selector = 'html .editor-styles-wrapper';
+				$paragraph_selector = 'html .editor-styles-wrapper p';
 			}
 
 			foreach ( $typography as $key => $data ) {
@@ -160,16 +169,7 @@ class GeneratePress_Typography {
 					$css->add_property( 'margin-bottom', $options['marginBottom'], false, $options['marginBottomUnit'] );
 				}
 
-				if ( 'frontend' === $type ) {
-					$css->start_media_query( generate_get_media_query( 'tablet' ) );
-				}
-
-				if ( 'editor' === $type ) {
-					// Add the tablet prefix to each class.
-					$selector = explode( ', ', $selector );
-					$selector = preg_filter( '/^/', $tablet_prefix, $selector );
-					$selector = implode( ', ', $selector );
-				}
+				$css->start_media_query( generate_get_media_query( 'tablet' ) );
 
 				$css->set_selector( $selector );
 				$css->add_property( 'font-size', $options['fontSizeTablet'], false, $options['fontSizeUnit'] );
@@ -179,24 +179,16 @@ class GeneratePress_Typography {
 					$css->add_property( 'line-height', $options['lineHeightTablet'], false, $options['lineHeightUnit'] );
 					$css->add_property( 'margin-bottom', $options['marginBottomTablet'], false, $options['marginBottomUnit'] );
 				} else {
-					$css->set_selector( $tablet_prefix . $body_selector );
+					$css->set_selector( $body_selector );
 					$css->add_property( 'line-height', $options['lineHeightTablet'], false, $options['lineHeightUnit'] );
 
-					$css->set_selector( $tablet_prefix . $paragraph_selector );
+					$css->set_selector( $paragraph_selector );
 					$css->add_property( 'margin-bottom', $options['marginBottomTablet'], false, $options['marginBottomUnit'] );
 				}
 
-				if ( 'frontend' === $type ) {
-					$css->stop_media_query();
-				}
+				$css->stop_media_query();
 
-				if ( 'frontend' === $type ) {
-					$css->start_media_query( generate_get_media_query( 'mobile' ) );
-				}
-
-				if ( 'editor' === $type ) {
-					$selector = str_replace( '.gp-is-device-tablet', '.gp-is-device-mobile', $selector );
-				}
+				$css->start_media_query( generate_get_media_query( 'mobile' ) );
 
 				$css->set_selector( $selector );
 				$css->add_property( 'font-size', $options['fontSizeMobile'], false, $options['fontSizeUnit'] );
@@ -206,16 +198,14 @@ class GeneratePress_Typography {
 					$css->add_property( 'line-height', $options['lineHeightMobile'], false, $options['lineHeightUnit'] );
 					$css->add_property( 'margin-bottom', $options['marginBottomMobile'], false, $options['marginBottomUnit'] );
 				} else {
-					$css->set_selector( $mobile_prefix . $body_selector );
+					$css->set_selector( $body_selector );
 					$css->add_property( 'line-height', $options['lineHeightMobile'], false, $options['lineHeightUnit'] );
 
-					$css->set_selector( $mobile_prefix . $paragraph_selector );
+					$css->set_selector( $paragraph_selector );
 					$css->add_property( 'margin-bottom', $options['marginBottomMobile'], false, $options['marginBottomUnit'] );
 				}
 
-				if ( 'frontend' === $type ) {
-					$css->stop_media_query();
-				}
+				$css->stop_media_query();
 			}
 
 			return $css->css_output();
@@ -288,7 +278,7 @@ class GeneratePress_Typography {
 		if ( 'editor' === $type ) {
 			switch ( $selector ) {
 				case 'body':
-					$selector = 'body .editor-styles-wrapper';
+					$selector = 'html .editor-styles-wrapper';
 					break;
 
 				case 'buttons':
@@ -377,6 +367,19 @@ class GeneratePress_Typography {
 			'marginBottomMobile' => '',
 			'marginBottomUnit' => 'px',
 		);
+	}
+
+	/**
+	 * Add editor styles to the block editor.
+	 *
+	 * @param array $editor_styles Existing styles.
+	 */
+	public function add_editor_styles( $editor_styles ) {
+		if ( generate_is_using_dynamic_typography() ) {
+			$editor_styles[] = 'assets/css/admin/editor-typography.css';
+		}
+
+		return $editor_styles;
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generatepress",
-  "version": "3.1.3-beta.1",
+  "version": "3.1.3",
   "description": "A super lightweight WordPress theme.",
   "main": "Gruntfile.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generatepress",
-  "version": "3.1.2",
+  "version": "3.1.3-beta.1",
   "description": "A super lightweight WordPress theme.",
   "main": "Gruntfile.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -104,8 +104,8 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 Release date: February 8, 2022
 
 * Fix: Adjust editor block width selector to fix compatibility with GP Premium
-* Fix: Typography selectors in the editor
-* Fix: Google Fonts API request in the editor when viewing tablet or mobile
+* Fix: Missing editor styles when viewing tablet/mobile previews in Firefox
+* Fix: Missing Google Fonts API request when viewing tablet/mobile previews in the editor
 
 = 3.1.2 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,8 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 Release date: TBA
 
 * Fix: Adjust editor block width selector to fix compatibility with GP Premium
+* Fix: Typography selectors in the editor
+* Fix: Google Fonts API request in the editor when viewing tablet or mobile
 
 = 3.1.2 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,10 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 
 == Changelog ==
 
+= 3.1.3 =
+
+Release date: TBA
+
 = 3.1.2 =
 
 Release date: January 31, 2022

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Tags: two-columns, three-columns, one-column, right-sidebar, left-sidebar, footer-widgets, blog, e-commerce, flexible-header, full-width-template, buddypress, custom-header, custom-background, custom-menu, custom-colors, sticky-post, threaded-comments, translation-ready, rtl-language-support, featured-images, theme-options
 Requires at least: 5.2
 Tested up to: 5.9
-Stable tag: 3.1.2
+Stable tag: 3.1.3
 
 GeneratePress is a lightweight WordPress theme built with a focus on speed and usability.
 

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,8 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 
 Release date: TBA
 
+* Fix: Adjust editor block width selector to fix compatibility with GP Premium
+
 = 3.1.2 =
 
 Release date: January 31, 2022

--- a/readme.txt
+++ b/readme.txt
@@ -101,7 +101,7 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 
 = 3.1.3 =
 
-Release date: TBA
+Release date: February 8, 2022
 
 * Fix: Adjust editor block width selector to fix compatibility with GP Premium
 * Fix: Typography selectors in the editor

--- a/readme.txt
+++ b/readme.txt
@@ -101,7 +101,7 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 
 = 3.1.3 =
 
-Release date: February 8, 2022
+Release date: February 9, 2022
 
 * Fix: Adjust editor block width selector to fix compatibility with GP Premium
 * Fix: Missing editor styles when viewing tablet/mobile previews in Firefox

--- a/sass/editor-typography.scss
+++ b/sass/editor-typography.scss
@@ -8,6 +8,7 @@ body {
 
 p {
 	line-height: inherit;
+	font-size: inherit;
 	margin-top: 0;
 	margin-bottom: 1.5em;
 }

--- a/sass/editor-typography.scss
+++ b/sass/editor-typography.scss
@@ -1,67 +1,67 @@
-.editor-styles-wrapper {
+body {
 	font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 	font-weight: normal;
 	text-transform: none;
 	font-size: 17px;
 	line-height: 1.5;
+}
 
-	p {
-		line-height: 1.5;
-		margin-top: 0;
-		margin-bottom: 1.5em;
-	}
+p {
+	line-height: inherit;
+	margin-top: 0;
+	margin-bottom: 1.5em;
+}
 
-	h1, h2, h3, h4, h5, h6 {
-		font-family: inherit;
-		font-size: 100%;
-		font-style: inherit;
-		font-weight: inherit;
-	}
+h1, h2, h3, h4, h5, h6 {
+	font-family: inherit;
+	font-size: 100%;
+	font-style: inherit;
+	font-weight: inherit;
+}
 
-	h1,
-	.editor-post-title__input {
-		font-family: inherit;
-		font-size: 42px;
-		margin-bottom: 20px;
-		margin-top: 0;
-		line-height: 1.2em;
-		font-weight: normal;
-		text-transform: none;
-	}
+h1,
+.editor-post-title__input {
+	font-family: inherit;
+	font-size: 42px;
+	margin-bottom: 20px;
+	margin-top: 0;
+	line-height: 1.2em;
+	font-weight: normal;
+	text-transform: none;
+}
 
-	h2 {
-		font-family: inherit;
-		font-size: 35px;
-		margin-bottom: 20px;
-		margin-top: 0;
-		line-height: 1.2em;
-		font-weight: normal;
-		text-transform: none;
-	}
+h2 {
+	font-family: inherit;
+	font-size: 35px;
+	margin-bottom: 20px;
+	margin-top: 0;
+	line-height: 1.2em;
+	font-weight: normal;
+	text-transform: none;
+}
 
-	h3 {
-		font-family: inherit;
-		font-size: 29px;
-		margin-bottom: 20px;
-		margin-top: 0;
-		line-height: 1.2em;
-		font-weight: normal;
-		text-transform: none;
-	}
+h3 {
+	font-family: inherit;
+	font-size: 29px;
+	margin-bottom: 20px;
+	margin-top: 0;
+	line-height: 1.2em;
+	font-weight: normal;
+	text-transform: none;
+}
 
-	h4 {
-		font-size: 24px;
-	}
+h4 {
+	font-size: 24px;
+}
 
-	h5 {
-		font-size: 20px;
-	}
+h5 {
+	font-size: 20px;
+}
 
-	h4,
-	h5,
-	h6 {
-		font-family: inherit;
-		margin-bottom: 20px;
-		margin-top: 0;
-	}
+h4,
+h5,
+h6 {
+	font-family: inherit;
+	margin-bottom: 20px;
+	margin-top: 0;
 }

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://generatepress.com
 Author: Tom Usborne
 Author URI: https://tomusborne.com
 Description: GeneratePress is a lightweight WordPress theme built with a focus on speed and usability. Performance is important to us, which is why a fresh GeneratePress install adds less than 10kb (gzipped) to your page size. We take full advantage of the block editor (Gutenberg), which gives you more control over creating your content. If you use page builders, GeneratePress is the right theme for you. It is completely compatible with all major page builders, including Beaver Builder and Elementor. Thanks to our emphasis on WordPress coding standards, we can boast full compatibility with all well-coded plugins, including WooCommerce. GeneratePress is fully responsive, uses valid HTML/CSS, and is translated into over 25 languages by our amazing community of users. A few of our many features include 60+ color controls, powerful dynamic typography, 5 navigation locations, 5 sidebar layouts, dropdown menus (click or hover), and 9 widget areas. Learn more and check out our powerful premium version at https://generatepress.com
-Version: 3.1.2
+Version: 3.1.3-beta.1
 Requires at least: 5.2
 Tested up to: 5.9
 Requires PHP: 5.6

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://generatepress.com
 Author: Tom Usborne
 Author URI: https://tomusborne.com
 Description: GeneratePress is a lightweight WordPress theme built with a focus on speed and usability. Performance is important to us, which is why a fresh GeneratePress install adds less than 10kb (gzipped) to your page size. We take full advantage of the block editor (Gutenberg), which gives you more control over creating your content. If you use page builders, GeneratePress is the right theme for you. It is completely compatible with all major page builders, including Beaver Builder and Elementor. Thanks to our emphasis on WordPress coding standards, we can boast full compatibility with all well-coded plugins, including WooCommerce. GeneratePress is fully responsive, uses valid HTML/CSS, and is translated into over 25 languages by our amazing community of users. A few of our many features include 60+ color controls, powerful dynamic typography, 5 navigation locations, 5 sidebar layouts, dropdown menus (click or hover), and 9 widget areas. Learn more and check out our powerful premium version at https://generatepress.com
-Version: 3.1.3-beta.1
+Version: 3.1.3
 Requires at least: 5.2
 Tested up to: 5.9
 Requires PHP: 5.6


### PR DESCRIPTION
This release is focused on fixing some editor bugs in WordPress 5.9.

Release date: February 9, 2022

* Fix: Adjust editor block width selector to fix compatibility with GP Premium
* Fix: Missing editor styles when viewing tablet/mobile previews in Firefox
* Fix: Missing Google Fonts API request when viewing tablet/mobile previews in the editor

- [x] Run builds
- [x] Update version: package.json
- [x] Update version: plugin/style.css header
- [x] Update version: PHP constant
- [x] Update version: readme.txt stable tag
- [x] Update changelog
- [x] Test for PHP parse errors
- [x] Test PHP 5.6+