### PR TITLE
Fix editor heading selectors

### DIFF
--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -286,11 +286,11 @@ class GeneratePress_Typography {
 					break;
 
 				case 'all-headings':
-					$selector = '.editor-styles-wrapper h1, .editor-styles-wrapper h2, .editor-styles-wrapper h3, .editor-styles-wrapper h4, .editor-styles-wrapper h5, .editor-styles-wrapper h6';
+					$selector = 'html .editor-styles-wrapper h1, html .editor-styles-wrapper h2, html .editor-styles-wrapper h3, html .editor-styles-wrapper h4, html .editor-styles-wrapper h5, html .editor-styles-wrapper h6';
 					break;
 
 				case 'h1':
-					$selector = '.editor-styles-wrapper h1, .editor-styles-wrapper .editor-post-title__input';
+					$selector = 'html .editor-styles-wrapper h1, .editor-styles-wrapper .editor-post-title__input';
 					break;
 
 				case 'single-content-title':
@@ -302,7 +302,7 @@ class GeneratePress_Typography {
 				case 'h4':
 				case 'h5':
 				case 'h6':
-					$selector = '.editor-styles-wrapper ' . $selector;
+					$selector = 'html .editor-styles-wrapper ' . $selector;
 					break;
 			}
 		}

--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -290,11 +290,11 @@ class GeneratePress_Typography {
 					break;
 
 				case 'h1':
-					$selector = 'html .editor-styles-wrapper h1, .editor-styles-wrapper .editor-post-title__input';
+					$selector = 'html .editor-styles-wrapper h1, html .editor-styles-wrapper .editor-post-title__input';
 					break;
 
 				case 'single-content-title':
-					$selector = '.editor-styles-wrapper .editor-post-title__input';
+					$selector = 'html .editor-styles-wrapper .editor-post-title__input';
 					break;
 
 				case 'h2':


### PR DESCRIPTION
This fixes an issue where CSS generated for headings wasn't working in the editor.

To test:

1. Go to Customize > Typography > Heading 1 - set font weight, size, etc...
2. Check editor H1 element in `3.1.3` branch vs this PR.