### PR TITLE
Fix Google Fonts request in editor prior to WP 5.8

### DIFF
--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -38,6 +38,7 @@ class GeneratePress_Typography {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_google_fonts' ) );
 		add_filter( 'generate_editor_styles', array( $this, 'add_editor_styles' ) );
 
+		// Load fonts the old way in versions before 5.8 as block_editor_settings_all didn't exist.
 		if ( version_compare( $GLOBALS['wp_version'], '5.8', '<' ) ) {
 			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_google_fonts' ) );
 		}

--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -37,6 +37,10 @@ class GeneratePress_Typography {
 	public function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_google_fonts' ) );
 		add_filter( 'generate_editor_styles', array( $this, 'add_editor_styles' ) );
+
+		if ( version_compare( $GLOBALS['wp_version'], '5.8', '<' ) ) {
+			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_google_fonts' ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
In 3.1.3 we've switched to loading the Google Fonts request using the `block_editor_settings_all` filter: https://developer.wordpress.org/reference/hooks/block_editor_settings_all/

This filter didn't exist before 5.8, so this PR loads the request the old way in those older versions.