### PR TITLE
Fix code block width in the editor

### DIFF
--- a/assets/css/admin/block-editor.css
+++ b/assets/css/admin/block-editor.css
@@ -10,7 +10,6 @@
 	margin-bottom: 1.5em;
 	padding: 20px;
 	overflow: auto;
-	max-width: 100%;
 	color: inherit; /* editor only */
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,8 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 
 Release date: TBA
 
+* Fix: Code block width in the editor
+
 = 3.1.3 =
 
 Release date: February 9, 2022


### PR DESCRIPTION
This PR fixes a bug where the Code block is always full width in the editor.

To test:

1. Add a Code block
2. Without this PR, it's full width. With this PR, it should be the same width as everything else.