### PR TITLE
Missing link underlines in the editor

### DIFF
--- a/assets/css/admin/block-editor.css
+++ b/assets/css/admin/block-editor.css
@@ -1,7 +1,3 @@
-.wp-block a {
-	text-decoration: none;
-}
-
 .block-editor-block-list__layout pre {
 	background: rgba(0, 0, 0, 0.05);
 	font-family: inherit;

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,8 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 
 Release date: TBA
 
+* Fix: Missing link underlines in the editor
+
 = 3.1.3 =
 
 Release date: February 9, 2022


### PR DESCRIPTION
This PR fixes missing link underlines in the editor. Link underline logic is handled in `block-editor.php` based on the users settings in the Customizer.