### PR TITLE
Remove title attributes from logo and logo link

### DIFF
--- a/inc/structure/header.php
+++ b/inc/structure/header.php
@@ -112,7 +112,6 @@ if ( ! function_exists( 'generate_construct_logo' ) ) {
 				'class' => 'header-image is-logo-image',
 				'alt'   => esc_attr( apply_filters( 'generate_logo_title', get_bloginfo( 'name', 'display' ) ) ),
 				'src'   => $logo_url,
-				'title' => esc_attr( apply_filters( 'generate_logo_title', get_bloginfo( 'name', 'display' ) ) ),
 			)
 		);
 
@@ -152,12 +151,11 @@ if ( ! function_exists( 'generate_construct_logo' ) ) {
 			'generate_logo_output',
 			sprintf(
 				'<div class="site-logo">
-					<a href="%1$s" title="%2$s" rel="home">
-						<img %3$s />
+					<a href="%1$s" rel="home">
+						<img %2$s />
 					</a>
 				</div>',
 				esc_url( apply_filters( 'generate_logo_href', home_url( '/' ) ) ),
-				esc_attr( apply_filters( 'generate_logo_title', get_bloginfo( 'name', 'display' ) ) ),
 				$html_attr
 			),
 			$logo_url,


### PR DESCRIPTION
Closes #318 

This removes the `title` attribute from the logo and the link surrounding the logo. They're not needed as the logo already has an `alt` attribute with the same value.