### PR TITLE
Remove excess screen reader text from post navigation

### DIFF
--- a/inc/class-html-attributes.php
+++ b/inc/class-html-attributes.php
@@ -311,7 +311,7 @@ class GeneratePress_HTML_Attributes {
 	public function post_navigation( $attributes ) {
 		if ( is_single() ) {
 			$attributes['class'] .= ' post-navigation';
-			$attributes['aria-label'] = esc_attr__( 'Single Post', 'generatepress' );
+			$attributes['aria-label'] = esc_attr__( 'Posts', 'generatepress' );
 		} else {
 			$attributes['class'] .= ' paging-navigation';
 			$attributes['aria-label'] = esc_attr__( 'Archive Page', 'generatepress' );

--- a/inc/structure/post-meta.php
+++ b/inc/structure/post-meta.php
@@ -36,16 +36,14 @@ if ( ! function_exists( 'generate_content_nav' ) ) {
 		}
 		?>
 		<nav <?php generate_do_attr( 'post-navigation', array( 'id' => esc_attr( $nav_id ) ) ); ?>>
-			<span class="screen-reader-text"><?php esc_html_e( 'Post navigation', 'generatepress' ); ?></span>
-
 			<?php
 			if ( is_single() ) : // navigation links for single posts.
 
 				$post_navigation_args = apply_filters(
 					'generate_post_navigation_args',
 					array(
-						'previous_format' => '<div class="nav-previous">' . generate_get_svg_icon( 'arrow-left' ) . '<span class="prev" title="' . esc_attr__( 'Previous', 'generatepress' ) . '">%link</span></div>',
-						'next_format' => '<div class="nav-next">' . generate_get_svg_icon( 'arrow-right' ) . '<span class="next" title="' . esc_attr__( 'Next', 'generatepress' ) . '">%link</span></div>',
+						'previous_format' => '<div class="nav-previous">' . generate_get_svg_icon( 'arrow-left' ) . '<span class="prev">%link</span></div>',
+						'next_format' => '<div class="nav-next">' . generate_get_svg_icon( 'arrow-right' ) . '<span class="next">%link</span></div>',
 						'link' => '%title',
 						'in_same_term' => apply_filters( 'generate_category_post_navigation', false ),
 						'excluded_terms' => '',


### PR DESCRIPTION
Closes #320 

This removes the screen reader text element and the title attributes from our single post navigation. It also changes the `aria-label` value to be a little more clear "Posts navigation" vs "Single Post navigation".