### PR TITLE
Fix woocommerce archive wrapper attributes

### DIFF
--- a/inc/class-html-attributes.php
+++ b/inc/class-html-attributes.php
@@ -116,6 +116,9 @@ class GeneratePress_HTML_Attributes {
 
 			case 'footer-entry-meta':
 				return $this->footer_entry_meta( $attributes );
+
+			case 'woocommerce-content':
+				return $this->woocommerce_content( $attributes );
 		}
 
 		return $attributes;
@@ -457,6 +460,34 @@ class GeneratePress_HTML_Attributes {
 	public function footer_entry_meta( $attributes ) {
 		$attributes['class'] .= ' entry-meta';
 		$attributes['aria-label'] = esc_attr__( 'Entry meta', 'generatepress' );
+
+		return $attributes;
+	}
+
+	/**
+	 * Add attributes to our WooCommerce content container.
+	 *
+	 * @since 3.2.0
+	 * @param array $attributes The existing attributes.
+	 */
+	public function woocommerce_content( $attributes ) {
+		if ( is_singular() ) {
+			$attributes['id'] = 'post-' . get_the_ID();
+			$attributes['class'] = esc_attr( implode( ' ', get_post_class( '', get_the_ID() ) ) );
+
+			if ( 'microdata' === generate_get_schema_type() ) {
+				$type = apply_filters( 'generate_article_itemtype', 'CreativeWork' );
+
+				$attributes['itemtype'] = sprintf(
+					'itemtype="https://schema.org/%s"',
+					$type
+				);
+
+				$attributes['itemscope'] = true;
+			}
+		} else {
+			$attributes['class'] = 'woocommerce-archive-wrapper';
+		}
 
 		return $attributes;
 	}

--- a/inc/plugin-compat.php
+++ b/inc/plugin-compat.php
@@ -32,6 +32,17 @@ function generate_setup_woocommerce() {
 	add_action( 'woocommerce_sidebar', 'generate_construct_sidebars' );
 }
 
+/**
+ * Get the tag name for our WooCommerce wrappers.
+ *
+ * @since 3.2.0
+ */
+function generate_get_woocommerce_wrapper_tagname() {
+	echo is_singular()
+		? 'article'
+		: 'div';
+}
+
 if ( ! function_exists( 'generate_woocommerce_start' ) ) {
 	add_action( 'woocommerce_before_main_content', 'generate_woocommerce_start', 10 );
 	/**
@@ -51,7 +62,7 @@ if ( ! function_exists( 'generate_woocommerce_start' ) ) {
 				 */
 				do_action( 'generate_before_main_content' );
 				?>
-				<article id="post-<?php the_ID(); ?>" <?php post_class(); ?> <?php generate_do_microdata( 'article' ); ?>>
+				<<?php generate_get_woocommerce_wrapper_tagname(); ?> <?php generate_do_attr( 'woocommerce-content' ); ?>>
 					<div class="inside-article">
 						<?php
 						/**
@@ -93,7 +104,7 @@ if ( ! function_exists( 'generate_woocommerce_end' ) ) {
 						do_action( 'generate_after_content' );
 						?>
 					</div>
-				</article>
+				</<?php generate_get_woocommerce_wrapper_tagname(); ?>>
 				<?php
 				/**
 				 * generate_after_main_content hook.


### PR DESCRIPTION
Closes #344 

This replaces the `<article>` element on WooCommerce archives that was pulling in the ID and classes of the first product in the loop. It now uses a simple `<div>` with a class.

We still use the `<article>` element on single products as it was before.

There's a slight chance of breakage if users are targeting this `article` element on WooCommerce archives, but I don't think it makes sense to use that element on the archive page.