### PR TITLE
Fix google fonts with standalone number

### DIFF
--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -75,6 +75,7 @@ class GeneratePress_Typography {
 			$variants = apply_filters( 'generate_google_font_variants', $variants, $font['fontFamily'] );
 
 			$name = str_replace( ' ', '+', $font['fontFamily'] );
+			$name = str_replace( '"', '', $name );
 
 			if ( $variants ) {
 				$data[] = $name . ':' . implode( ',', $variants );
@@ -338,6 +339,10 @@ class GeneratePress_Typography {
 		}
 
 		if ( ! empty( $font_family_args['googleFont'] ) && ! empty( $font_family_args['googleFontCategory'] ) ) {
+			if ( preg_match( '/\b(?<!-)\d+(?!-)\b/', $font_family ) ) {
+				$font_family = '"' . $font_family . '"';
+			}
+
 			$font_family = $font_family . ', ' . $font_family_args['googleFontCategory'];
 		} elseif ( 'System Default' === $font_family ) {
 			$font_family = generate_get_system_default_font();

--- a/inc/class-typography.php
+++ b/inc/class-typography.php
@@ -339,7 +339,8 @@ class GeneratePress_Typography {
 		}
 
 		if ( ! empty( $font_family_args['googleFont'] ) && ! empty( $font_family_args['googleFontCategory'] ) ) {
-			if ( preg_match( '/\b(?<!-)\d+(?!-)\b/', $font_family ) ) {
+			// Add quotations around font names with standalone numbers.
+			if ( preg_match( '/(?<!\S)\d+(?!\S)/', $font_family ) ) {
 				$font_family = '"' . $font_family . '"';
 			}
 


### PR DESCRIPTION
Closes #324 

This PR fixes this issue in two ways - but I think we only need one. I added both so we could take a look at what's best.

1. We allow people to add the quotations directly to the font name by stripping the `"` character from the Google font request.
2. We check for standalone numbers and wrap the font name with quotes if we find one.

1 requires the user to do the work and wrap the font name. Although we could try adding some logic into the font manager to do this for them

2 isn't as good for performance, and there might be other cases (not just standalone numbers) that require quotes.

I feel like 1 is the better solution, but we need to do some of the work for the user in the Customizer.