### PR TITLE
Fixed css for social button used in Footer widgets(Footer Sidebar)

### DIFF
--- a/sass/layout/footer/_footer.scss
+++ b/sass/layout/footer/_footer.scss
@@ -2,3 +2,7 @@
 	text-align: center;
 	font-size: 15px;
 }
+
+.wp-block-social-links li {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
Hello,
I used WP 6.0 latest version. When I add Gutenberg Social icons block inside the Footer Widget Area there is one issue with margin. I added CSS inside the SASS module, Can you guide me which node version are you using so i can install all node modules and run the grunt watch for minify css.

Thanks.