### PR TITLE
Add editor-only CSS to the block editor

### DIFF
--- a/assets/js/admin/block-editor.js
+++ b/assets/js/admin/block-editor.js
@@ -1,14 +1,10 @@
 jQuery( document ).ready( function( $ ) {
-	var container_width_elements = 'body .wp-block,\
-									html body.gutenberg-editor-page .editor-post-title__block,\
-	 								html body.gutenberg-editor-page .editor-default-block-appender,\
-									html body.gutenberg-editor-page .editor-block-list__block,\
-									.edit-post-visual-editor .editor-block-list__block[data-align=wide]';
+	var container_width_elements = '.editor-styles-wrapper .wp-block';
 
 	$( 'select[name="_generate-full-width-content"]' ).on( 'change', function() {
 		if ( 'true' === this.value ) {
 			$( 'style#container_width' ).remove();
-			$( 'head' ).append( '<style id="container_width">' + container_width_elements + '{max-width: 100%;}</style>' );
+			$( 'body' ).append( '<style id="container_width">' + container_width_elements + '{max-width: 100%;}</style>' );
 		} else {
 			$( 'style#container_width' ).remove();
 		}
@@ -42,10 +38,10 @@ jQuery( document ).ready( function( $ ) {
 			calc = 'max-width: calc(' + content_width + 'px - ' + right_content_padding + ' - ' + left_content_padding + ')';
 
 			$( 'style#content-width' ).remove();
-			$( 'head' ).append( '<style id="content-width">' + container_width_elements + '{' + calc + '}</style>' );
+			$( 'body' ).append( '<style id="content-width">' + container_width_elements + '{' + calc + '}</style>' );
 
 			$( 'style#wide-width' ).remove();
-			$( 'head' ).append( '<style id="wide-width">.edit-post-visual-editor .editor-block-list__block[data-align=wide]{max-width:' + content_width + 'px}' );
+			$( 'body' ).append( '<style id="wide-width">.edit-post-visual-editor .editor-block-list__block[data-align=wide]{max-width:' + content_width + 'px}' );
 		}
 	} );
 

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -145,6 +145,10 @@ function generate_enqueue_backend_block_editor_assets() {
 		true
 	);
 
+	wp_register_style( 'generate-block-editor', false, array(), true, true );
+	wp_add_inline_style( 'generate-block-editor', generate_do_inline_block_editor_css( 'block-editor' ) );
+	wp_enqueue_style( 'generate-block-editor' );
+
 	$color_settings = wp_parse_args(
 		get_option( 'generate_settings', array() ),
 		generate_get_color_defaults()
@@ -181,36 +185,13 @@ function generate_enqueue_backend_block_editor_assets() {
 }
 
 /**
- * Write our CSS for the block editor.
+ * Write our CSS that applies to blocks within the editor.
  *
  * @since 2.2
+ * @param string $for Is this CSS for the block content or the block editor.
  */
-function generate_do_inline_block_editor_css() {
-	$color_settings = wp_parse_args(
-		get_option( 'generate_settings', array() ),
-		generate_get_color_defaults()
-	);
-
-	$font_settings = wp_parse_args(
-		get_option( 'generate_settings', array() ),
-		generate_get_default_fonts()
-	);
-
+function generate_do_inline_block_editor_css( $for = 'block-content' ) {
 	$css = new GeneratePress_CSS();
-
-	$content_width = generate_get_block_editor_content_width();
-
-	$spacing_settings = wp_parse_args(
-		get_option( 'generate_spacing_settings', array() ),
-		generate_spacing_get_defaults()
-	);
-
-	$content_width_calc = sprintf(
-		'calc(%1$s - %2$s - %3$s)',
-		absint( $content_width ) . 'px',
-		absint( $spacing_settings['content_left'] ) . 'px',
-		absint( $spacing_settings['content_right'] ) . 'px'
-	);
 
 	$css->set_selector( ':root' );
 
@@ -233,6 +214,35 @@ function generate_do_inline_block_editor_css() {
 			}
 		}
 	}
+
+	// If this CSS is for the editor only (not the block content), we can return here.
+	if ( 'block-editor' === $for ) {
+		return $css->css_output();
+	}
+
+	$color_settings = wp_parse_args(
+		get_option( 'generate_settings', array() ),
+		generate_get_color_defaults()
+	);
+
+	$font_settings = wp_parse_args(
+		get_option( 'generate_settings', array() ),
+		generate_get_default_fonts()
+	);
+
+	$content_width = generate_get_block_editor_content_width();
+
+	$spacing_settings = wp_parse_args(
+		get_option( 'generate_spacing_settings', array() ),
+		generate_spacing_get_defaults()
+	);
+
+	$content_width_calc = sprintf(
+		'calc(%1$s - %2$s - %3$s)',
+		absint( $content_width ) . 'px',
+		absint( $spacing_settings['content_left'] ) . 'px',
+		absint( $spacing_settings['content_right'] ) . 'px'
+	);
 
 	$css->set_selector( 'body .wp-block' );
 

--- a/inc/block-editor.php
+++ b/inc/block-editor.php
@@ -185,10 +185,10 @@ function generate_enqueue_backend_block_editor_assets() {
 }
 
 /**
- * Write our CSS that applies to blocks within the editor.
+ * Write our CSS for the block editor.
  *
  * @since 2.2
- * @param string $for Is this CSS for the block content or the block editor.
+ * @param string $for Define whether this CSS for the block content or the block editor.
  */
 function generate_do_inline_block_editor_css( $for = 'block-content' ) {
 	$css = new GeneratePress_CSS();


### PR DESCRIPTION
The work we did in #343 caused styles to go missing from the actual editor page, like the global colors in the color picker:

<img width="1728" alt="missing-editor-styles" src="https://user-images.githubusercontent.com/20714883/170808087-950e6aa4-5e41-49d1-805d-fa758b91fa4b.png">

This PR adds a parameter to our block editor CSS function that returns early with our editor-specific CSS so we can enqueue it to the editor screen.