### PR TITLE
Tweak: Revert using GP button color variables in GB

### DIFF
--- a/inc/general.php
+++ b/inc/general.php
@@ -477,18 +477,3 @@ function generate_do_a11y_scripts() {
 		);
 	}
 }
-
-add_filter( 'generateblocks_default_block_styles', 'generate_set_gb_button_styles' );
-/**
- * Set the default colors for GenerateBlocks buttons.
- *
- * @param array $styles The default styles.
- */
-function generate_set_gb_button_styles( $styles ) {
-	$styles['button']['backgroundColor'] = 'var(--gp-button-background-color)';
-	$styles['button']['textColor'] = 'var(--gp-button-text-color)';
-	$styles['button']['backgroundColorHover'] = 'var(--gp-button-background-color-hover)';
-	$styles['button']['textColorHover'] = 'var(--gp-button-text-color-hover)';
-
-	return $styles;
-}


### PR DESCRIPTION
This reverts the change we made in this version where the `--gp-button-xx` CSS variables are added to newly added buttons in GenerateBlocks.

We feel like this feature is half-baked, as you can't mimic the GP button padding or typography.

We'll be exploring a better method that does all three.