### PR TITLE
Fix: Don't apply block margin to core Heading

### DIFF
--- a/inc/css-output.php
+++ b/inc/css-output.php
@@ -543,7 +543,7 @@ if ( ! function_exists( 'generate_font_css' ) ) {
 		$css->add_property( 'margin-bottom', floatval( $settings['paragraph_margin'] ), $defaults['paragraph_margin'], 'em' );
 
 		if ( apply_filters( 'generate_do_wp_block_margin_bottom', true ) ) {
-			$css->set_selector( '.entry-content > [class*="wp-block-"]:not(:last-child)' );
+			$css->set_selector( '.entry-content > [class*="wp-block-"]:not(:last-child):not(.wp-block-heading)' );
 			$css->add_property( 'margin-bottom', floatval( $settings['paragraph_margin'] ), false, 'em' );
 		}
 


### PR DESCRIPTION
This fixes an issue being introduced by WordPress.

To replicate:

1. Enable the legacy Typography system in GP by setting the `use_dynamic_typography` option in our `defaults.php` file to `false`.
2. Enable the Gutenberg plugin
3. Add a set of core Heading blocks to a page

The addition of the `wp-block-heading` class to the core Heading block makes it so our legacy block margin applies to the headings, instead of their inherited heading margins.