### PR TITLE
Fix: Comment fields PHP 8.1 notice

### DIFF
--- a/inc/structure/comments.php
+++ b/inc/structure/comments.php
@@ -156,8 +156,8 @@ function generate_set_comment_form_defaults( $defaults ) {
 		esc_html__( 'Comment', 'generatepress' )
 	);
 
-	$defaults['comment_notes_before'] = null;
-	$defaults['comment_notes_after']  = null;
+	$defaults['comment_notes_before'] = '';
+	$defaults['comment_notes_after']  = '';
 	$defaults['id_form']              = 'commentform';
 	$defaults['id_submit']            = 'submit';
 	$defaults['title_reply']          = apply_filters( 'generate_leave_comment', __( 'Leave a Comment', 'generatepress' ) );

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 
 * Tweak: Allow sub-menus to open using the spacebar
 * Fix: PHP 8.1 filter_input notice
+* Fix: Comment fields PHP 8.1 notice
 
 = 3.2.4 =
 


### PR DESCRIPTION
Reference: https://generatepress.com/forums/topic/php-8-1-deprecation-notice-for-generate_set_comment_form_defaults/