### PR TITLE
Fix: Allow rgb() color values

### DIFF
--- a/inc/customizer/helpers.php
+++ b/inc/customizer/helpers.php
@@ -208,8 +208,25 @@ if ( ! function_exists( 'generate_sanitize_hex_color' ) ) {
 			return $color;
 		}
 
+		// Sanitize CSS variables.
 		if ( strpos( $color, 'var(' ) !== false ) {
 			return sanitize_text_field( $color );
+		}
+
+		// Sanitize rgb() values.
+		if ( strpos( $color, 'rgb(' ) !== false ) {
+			$color = str_replace( ' ', '', $color );
+
+			sscanf( $color, 'rgb(%d,%d,%d)', $red, $green, $blue );
+			return 'rgb(' . $red . ',' . $green . ',' . $blue . ')';
+		}
+
+		// Sanitize rgba() values.
+		if ( strpos( $color, 'rgba' ) !== false ) {
+			$color = str_replace( ' ', '', $color );
+			sscanf( $color, 'rgba(%d,%d,%d,%f)', $red, $green, $blue, $alpha );
+
+			return 'rgba(' . $red . ',' . $green . ',' . $blue . ',' . $alpha . ')';
 		}
 
 		return '';


### PR DESCRIPTION
close #456 

This allows us to save `rgb()` values in the Customizer.

While testing I noticed that all of our color fields accept transparency now (body, text etc...) when they didn't use to. This isn't a bad thing, but `rgba()` values currently don't save in those fields as they're set to use `generate_sanitize_hex_color`. Instead of changing all of the sanitize fields to `generate_sanitize_rgba_color`, I just added in `rgba()` sanitizing into the hex function.