### PR TITLE
Fix: Mobile menu toggle alignment

### DIFF
--- a/inc/structure/navigation.php
+++ b/inc/structure/navigation.php
@@ -490,6 +490,10 @@ function generate_add_menu_bar_items() {
 	if ( 'enable' === generate_get_option( 'nav_search' ) ) {
 		add_action( 'generate_menu_bar_items', 'generate_do_navigation_search_button' );
 	}
+
+	if ( generate_get_option( 'nav_search_modal' ) ) {
+		add_action( 'generate_menu_bar_items', 'generate_do_search_modal_trigger' );
+	}
 }
 
 /**

--- a/inc/structure/search-modal.php
+++ b/inc/structure/search-modal.php
@@ -28,7 +28,6 @@ function generate_do_search_modal() {
 	<?php
 }
 
-add_action( 'generate_menu_bar_items', 'generate_do_search_modal_trigger' );
 /**
  * Create the search modal trigger.
  */

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,8 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 
 = 3.3.1 =
 
+* Fix: Mobile menu toggle alignment when navigation above/below header
+
 = 3.3.0 =
 
 * Feature: Add navigation search modal


### PR DESCRIPTION
close #523 

Not conditionally adding our menu bar item in the `wp` hook was making it so the `has-menu-bar-items` class was always being added even if there were no items.