### PR TITLE
Fix: Disable nav search modal if using floats or font icons

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1011,7 +1011,7 @@ if ( ! function_exists( 'generate_customize_register' ) ) {
 				'settings' => 'generate_settings[nav_search]',
 				'priority' => 23,
 				'active_callback' => function() {
-					return 'enable' === generate_get_option( 'nav_search' );
+					return 'enable' === generate_get_option( 'nav_search' ) || 'floats' === generate_get_option( 'structure' ) || 'font' === generate_get_option( 'icons' );
 				},
 			)
 		);
@@ -1033,7 +1033,7 @@ if ( ! function_exists( 'generate_customize_register' ) ) {
 				'section' => 'generate_layout_navigation',
 				'priority' => 23,
 				'active_callback' => function() {
-					return 'disable' === generate_get_option( 'nav_search' );
+					return 'disable' === generate_get_option( 'nav_search' ) && 'flexbox' === generate_get_option( 'structure' ) && 'svg' === generate_get_option( 'icons' );
 				},
 			)
 		);

--- a/inc/structure/navigation.php
+++ b/inc/structure/navigation.php
@@ -491,7 +491,7 @@ function generate_add_menu_bar_items() {
 		add_action( 'generate_menu_bar_items', 'generate_do_navigation_search_button' );
 	}
 
-	if ( generate_get_option( 'nav_search_modal' ) ) {
+	if ( generate_get_option( 'nav_search_modal' ) && 'flexbox' === generate_get_option( 'structure' ) && 'svg' === generate_get_option( 'icons' ) ) {
 		add_action( 'generate_menu_bar_items', 'generate_do_search_modal_trigger' );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ MIT License: https://github.com/JedWatson/react-select/blob/master/LICENSE
 = 3.3.1 =
 
 * Fix: Mobile menu toggle alignment when navigation above/below header
+* Fix: Disable nav search modal if using floats or font icons
 
 = 3.3.0 =
 


### PR DESCRIPTION
blocked #528 
close #526 

This is a "modern" feature that requires flexbox and SVG icons.

Users who are using floats or font icons should still see the old nav search option.