### PR TITLE
Fix: Remove prohibited attribute from header element

### DIFF
--- a/inc/class-html-attributes.php
+++ b/inc/class-html-attributes.php
@@ -287,7 +287,6 @@ class GeneratePress_HTML_Attributes {
 	 */
 	public function entry_header( $attributes ) {
 		$attributes['class'] .= ' entry-header';
-		$attributes['aria-label'] = esc_attr__( 'Content', 'generatepress' );
 
 		return $attributes;
 	}


### PR DESCRIPTION
Fixes: https://github.com/tomusborne/generatepress/issues/555