### PR TITLE
Add support for wp_get_loading_optimization_attributes

### DIFF
--- a/inc/structure/header.php
+++ b/inc/structure/header.php
@@ -112,6 +112,7 @@ if ( ! function_exists( 'generate_construct_logo' ) ) {
 				'class' => 'header-image is-logo-image',
 				'alt'   => esc_attr( apply_filters( 'generate_logo_title', get_bloginfo( 'name', 'display' ) ) ),
 				'src'   => $logo_url,
+				'decoding' => 'async',
 			)
 		);
 
@@ -131,6 +132,13 @@ if ( ! function_exists( 'generate_construct_logo' ) ) {
 			if ( isset( $data['height'] ) ) {
 				$attr['height'] = $data['height'];
 			}
+		}
+
+		if ( function_exists( 'wp_get_loading_optimization_attributes' ) ) {
+			$attr = array_merge(
+				$attr,
+				wp_get_loading_optimization_attributes( 'img', $attr, 'generate_construct_logo' )
+			);
 		}
 
 		$attr = array_map( 'esc_attr', $attr );


### PR DESCRIPTION
In WordPress 6.3, a new function was added to improve image loading. See https://make.wordpress.org/core/2023/07/13/image-performance-enhancements-in-wordpress-6-3/

This PR implements `wp_get_loading_optimization_attributes`, checking it exists. This change also includes a fix to add `decoding` attribute, added in WordPress 6.1. 

https://make.wordpress.org/core/2022/10/11/performance-field-guide-for-wordpress-6-1/
https://core.trac.wordpress.org/ticket/53232