### PR TITLE
Tweak: Update script dependencies

### DIFF
--- a/inc/class-dashboard.php
+++ b/inc/class-dashboard.php
@@ -204,7 +204,7 @@ class GeneratePress_Dashboard {
 				wp_enqueue_script(
 					'generate-dashboard',
 					get_template_directory_uri() . '/assets/dist/dashboard.js',
-					array( 'wp-api', 'wp-i18n', 'wp-components', 'wp-element', 'wp-api-fetch' ),
+					array( 'wp-api', 'wp-i18n', 'wp-components', 'wp-element', 'wp-api-fetch', 'wp-hooks', 'wp-polyfill' ),
 					GENERATE_VERSION,
 					true
 				);

--- a/inc/customizer/helpers.php
+++ b/inc/customizer/helpers.php
@@ -340,7 +340,7 @@ function generate_do_control_inline_scripts() {
 		'generate-customizer-controls',
 		trailingslashit( get_template_directory_uri() ) . 'assets/dist/customizer.js',
 		// We're including wp-color-picker for localized strings, nothing more.
-		array( 'customize-controls', 'wp-i18n', 'wp-components', 'wp-element', 'jquery', 'customize-base', 'wp-color-picker' ),
+		array( 'lodash', 'react', 'react-dom', 'wp-components', 'wp-element', 'wp-hooks', 'wp-i18n', 'wp-polyfill', 'jquery', 'customize-base', 'customize-controls', 'wp-color-picker' ),
 		GENERATE_VERSION,
 		true
 	);


### PR DESCRIPTION
This manually updates our script dependencies in the Customizer and Dashboard.

In 3.4, we should add automatic dependency loading so we don't have to update these in the future.

This should fix #561 in theory, but I'm not 100% sure as I can't replicate the issue.