### PR TITLE
Fix: Aria-label/read more to pass PageSpeed & A11y

### DIFF
--- a/inc/structure/post-meta.php
+++ b/inc/structure/post-meta.php
@@ -456,7 +456,7 @@ if ( ! function_exists( 'generate_excerpt_more' ) ) {
 				__( 'Read more', 'generatepress' ),
 				sprintf(
 					/* translators: Aria-label describing the read more button */
-					_x( 'More on %s', 'more on post title', 'generatepress' ),
+					_x( 'Read more about %s', 'more about post title', 'generatepress' ),
 					the_title_attribute( 'echo=0' )
 				)
 			)
@@ -484,7 +484,7 @@ if ( ! function_exists( 'generate_content_more' ) ) {
 				__( 'Read more', 'generatepress' ),
 				sprintf(
 					/* translators: Aria-label describing the read more button */
-					_x( 'More on %s', 'more on post title', 'generatepress' ),
+					_x( 'Read more about %s', 'more about post title', 'generatepress' ),
 					the_title_attribute( 'echo=0' )
 				)
 			)


### PR DESCRIPTION
Fixes #564 

Hey! I found this issue when I ran PageSpeed on a site I built. Big fan of GP and thought I'd make a contribution if you'd accept it. I'm just starting to dive into Wordpress development, so any tips or suggestions are more than welcome :)

I went with standard wording "Read more [...]" as in [example #1 here](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA8.html)