### PR TITLE
Fix: Color picker outline

### DIFF
--- a/src/components/color-picker/style.scss
+++ b/src/components/color-picker/style.scss
@@ -158,6 +158,7 @@
 			left: 0;
 			border: 0;
 			box-shadow: inset 0 0 0 2px #757575;
+			transform: none;
 		}
 	}
 }


### PR DESCRIPTION
This fixes a bug where the color picker outline in the Customizer appears out of place when the color picker toggle is focused/active.