### PR TITLE
Fixed issue with missing 'ch' unit for line-height in customizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generatepress",
-  "version": "3.4.0-alpha.1",
+  "version": "3.4.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generatepress",
-      "version": "3.4.0-alpha.1",
+      "version": "3.4.0-beta.1",
       "license": "GNU General Public License v2 or later",
       "dependencies": {
         "classnames": "2.3.2",

--- a/src/customizer-controls/font-manager/TypographyList/TypographySettings/DeviceInputGroup.js
+++ b/src/customizer-controls/font-manager/TypographyList/TypographySettings/DeviceInputGroup.js
@@ -7,6 +7,7 @@ const DeviceInputGroup = ( props ) => {
 	const {
 		label,
 		units,
+		unitCount = 7,
 		defaultUnit = '',
 		desktopValue,
 		desktopInitial,
@@ -34,6 +35,7 @@ const DeviceInputGroup = ( props ) => {
 					<UnitControl
 						key={ device }
 						units={ units }
+						unitCount={ unitCount }
 						value={ desktopValue }
 						placeholder={ desktopInitial }
 						onChange={ desktopOnChange }
@@ -45,6 +47,7 @@ const DeviceInputGroup = ( props ) => {
 					<UnitControl
 						key={ device }
 						units={ units }
+						unitCount={ unitCount }
 						value={ tabletValue }
 						placeholder={ tabletInitial }
 						onChange={ tabletOnChange }
@@ -56,6 +59,7 @@ const DeviceInputGroup = ( props ) => {
 					<UnitControl
 						key={ device }
 						units={ units }
+						unitCount={ unitCount }
 						value={ mobileValue }
 						placeholder={ mobileInitial }
 						onChange={ mobileOnChange }

--- a/src/customizer-controls/font-manager/TypographyList/TypographySettings/LineHeight.js
+++ b/src/customizer-controls/font-manager/TypographyList/TypographySettings/LineHeight.js
@@ -7,6 +7,7 @@ const LineHeight = ( { font, onChange } ) => {
 		<DeviceInputGroup
 			label={ __( 'Line Height', 'generatepress' ) }
 			units={ [ '' ] }
+			unitCount="8"
 			defaultUnit="em"
 
 			desktopValue={ font.lineHeight }


### PR DESCRIPTION
When using the no unit option, this cuts off the 'ch' unit.

### After:

The 'ch' unit is restored.

![image](https://github.com/tomusborne/generatepress/assets/1482075/40d649ec-fc2c-4939-8ada-1aa26b422d43)
