### PR TITLE
Add dashboard padding

### DIFF
--- a/src/dashboard/style.scss
+++ b/src/dashboard/style.scss
@@ -64,6 +64,7 @@
 .generatepress-dashboard {
 	max-width: 1000px;
 	margin: 40px auto;
+	padding: 0 30px;
 	font-size: 15px;
 
 	h2 {


### PR DESCRIPTION
Looked a bit tight at narrower admin screen widths.

## Before

![image](https://github.com/tomusborne/generatepress/assets/1482075/dbb4430e-6af2-4443-a2c6-35161dec4468)

## After

![image](https://github.com/tomusborne/generatepress/assets/1482075/72a74964-fc22-4c18-bd09-771e242b01e8)
