### PR TITLE
Add aria-label to arrow dropdown for accesibility

### DIFF
--- a/assets/css/all.css
+++ b/assets/css/all.css
@@ -1205,6 +1205,7 @@ a {
 .main-navigation .main-nav ul li.menu-item-has-children > a {
 	padding-right: 0;
 	position: relative;
+	flex-grow: 1;
 }
 
 .main-navigation.sub-menu-left ul ul {
@@ -1217,6 +1218,7 @@ a {
 
 .main-navigation:not(.toggled) ul li:hover > ul,
 .main-navigation:not(.toggled) ul li.sfHover > ul {
+	top: 100%;
 	left: auto;
 	opacity: 1;
 	transition-delay: 150ms;
@@ -1241,18 +1243,26 @@ a {
 	top: 0;
 }
 
+.menu-item-has-children{
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+}
+
 .menu-item-has-children .dropdown-menu-toggle {
 	display: inline-block;
 	height: 100%;
 	clear: both;
 	padding-right: 20px;
 	padding-left: 10px;
+	color: inherit;
+	background: transparent;
 }
 
 .menu-item-has-children ul .dropdown-menu-toggle {
-	padding-top: 10px;
-	padding-bottom: 10px;
-	margin-top: -10px;
+	padding-top: 4px;
+	padding-bottom: 4px;
+	line-height: 1;
 }
 
 nav ul ul .menu-item-has-children .dropdown-menu-toggle,
@@ -2419,6 +2429,10 @@ nav.toggled ul ul.sub-menu {
 
 .main-navigation.toggled .main-nav li.hide-on-mobile {
 	display: none !important;
+}
+
+.menu-item-has-children ul.toggled-on{
+	top: 100%;
 }
 
 .main-navigation.toggled .menu-item-has-children .dropdown-menu-toggle {

--- a/assets/js/dropdown-click.js
+++ b/assets/js/dropdown-click.js
@@ -73,7 +73,7 @@
 				}
 			}
 
-			var dropdownToggleLinks = document.querySelectorAll( '.main-nav .menu-item-has-children > a .dropdown-menu-toggle' );
+			var dropdownToggleLinks = document.querySelectorAll( '.main-nav .menu-item-has-children > .dropdown-menu-toggle' );
 			for ( i = 0; i < dropdownToggleLinks.length; i++ ) {
 				dropdownToggleLinks[ i ].addEventListener( 'click', dropdownClick, false );
 

--- a/inc/structure/navigation.php
+++ b/inc/structure/navigation.php
@@ -371,6 +371,7 @@ if ( ! function_exists( 'generate_dropdown_icon_to_menu_link' ) ) {
 		if ( 'click-arrow' === generate_get_option( 'nav_dropdown_type' ) ) {
 			$role = 'button';
 			$tabindex = ' tabindex="0"';
+			$aria_label = sprintf(' aria-label="%s: submenu"', $title);
 		}
 
 		if ( isset( $args->container_class ) && 'main-nav' === $args->container_class ) {
@@ -417,7 +418,7 @@ if ( ! function_exists( 'generate_dropdown_icon_to_menu_link' ) ) {
 					}
 
 					$icon = generate_get_svg_icon( 'arrow' . $arrow_direction );
-					$title = $title . '<span role="' . $role . '" class="dropdown-menu-toggle"' . $tabindex . '>' . $icon . '</span>';
+					$title = $title . '<span role="' . $role . '" class="dropdown-menu-toggle"' . $tabindex . $aria_label . '>' . $icon . '</span>';
 				}
 			}
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generatepress",
-  "version": "3.4.0-alpha.1",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generatepress",
-      "version": "3.4.0-alpha.1",
+      "version": "3.4.0",
       "license": "GNU General Public License v2 or later",
       "dependencies": {
         "classnames": "2.3.2",


### PR DESCRIPTION
When using a screen reader, you should be able to tab to the dropdown to be able to enter.

It should clearly explain what the button group you is/does. Adding an aria label will read $title: submenu.

Example:
Equalize digital use an aria label on the dropdown arrow with the same markup to clearly explain to the user what the button does. https://equalizedigital.com/