### PR TITLE
Tweak: Use `getDevicePreview`

### DIFF
--- a/src/extend/responsive-classes/index.js
+++ b/src/extend/responsive-classes/index.js
@@ -7,22 +7,28 @@ import {
 	select,
 } from '@wordpress/data';
 
+import { store as editorStore } from '@wordpress/editor';
+
 const SetResponsiveClasses = () => {
 	const {
 		deviceType,
 	} = useSelect( () => {
 		const {
-			__experimentalGetPreviewDeviceType: getPreviewDeviceType,
-		} = select( 'core/edit-post' );
+			getDeviceType: getPreviewDeviceType = () => false,
+		} = select( editorStore );
 
-		if ( ! getPreviewDeviceType ) {
+		if ( getPreviewDeviceType() ) {
 			return {
-				deviceType: null,
+				deviceType: getPreviewDeviceType(),
 			};
 		}
 
+		const {
+			__experimentalGetPreviewDeviceType: experimentalGetPreviewDeviceType = () => 'Desktop',
+		} = select( 'core/edit-post' );
+
 		return {
-			deviceType: getPreviewDeviceType(),
+			deviceType: experimentalGetPreviewDeviceType(),
 		};
 	}, [] );
 


### PR DESCRIPTION
This uses the new (in WP 6.5) `getDevicePreview` function to get the editor device preview.

It falls back to the old experimental function for users who aren't using 6.5, yet.