### PR TITLE
Tweak: Add customizer color live preview to woo buttons

### DIFF
--- a/inc/customizer/fields/buttons.php
+++ b/inc/customizer/fields/buttons.php
@@ -38,6 +38,11 @@ GeneratePress_Customize_Field::add_wrapper(
 $buttons_selector = 'button, html input[type="button"], input[type="reset"], input[type="submit"], a.button, a.button:visited, a.wp-block-button__link:not(.has-background)';
 $buttons_hover_selector = 'button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover, a.button:hover, button:focus, html input[type="button"]:focus, input[type="reset"]:focus, input[type="submit"]:focus, a.button:focus, a.wp-block-button__link:not(.has-background):active, a.wp-block-button__link:not(.has-background):focus, a.wp-block-button__link:not(.has-background):hover';
 
+if ( defined( 'GP_PREMIUM_VERSION' ) && version_compare( GP_PREMIUM_VERSION, '2.4.1', '>' ) ) {
+	$buttons_selector .= ', .wc-block-components-button';
+	$buttons_hover_selector .= ', .wc-block-components-button:hover';
+}
+
 GeneratePress_Customize_Field::add_field(
 	'generate_settings[form_button_background_color]',
 	'GeneratePress_Customize_Color_Control',


### PR DESCRIPTION
This allows our button color live preview in the Customizer to apply to WooCommerce blocks.

Related: https://github.com/tomusborne/gp-premium/pull/512