### PR TITLE
Fix: Stale typography values in the Customizer

### DIFF
--- a/src/customizer-controls/font-manager/GeneratePressTypographyControlForm.js
+++ b/src/customizer-controls/font-manager/GeneratePressTypographyControlForm.js
@@ -117,7 +117,7 @@ const GeneratePressTypographyControlForm = ( props ) => {
 			<Button
 				isPrimary
 				onClick={ () => {
-					const fontValues = [ ...props.value ];
+					const fontValues = [ ...fonts ];
 
 					fontValues.push( {
 						selector: '',


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/tomusborne/generatepress/pull/606