### PR TITLE
Fix: Menu dropdown arrow click a11y fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
 		"jQuery": "readonly",
 		"ajaxurl": "readonly",
 		"generatepressMenu": "readonly",
+		"generatepressDropdownClick": "readonly",
 		"generatepressNavSearch": "readonly",
 		"generateCustomizerControls": "readonly",
 		"generateDashboard": "readonly",

--- a/assets/js/dropdown-click.js
+++ b/assets/js/dropdown-click.js
@@ -4,6 +4,28 @@
 	if ( 'querySelector' in document && 'addEventListener' in window ) {
 		var body = document.body,
 			i;
+
+		// Add missing aria roles and attributes for accessibility.
+		var allSubMenus = document.querySelectorAll( '.main-nav .sub-menu, .main-nav .children' );
+
+		if ( allSubMenus ) {
+			allSubMenus.forEach( function( subMenu ) {
+				var parentLi = subMenu.closest( 'li' );
+				var button = parentLi.querySelector( '[role="button"]' );
+
+				// Bail if no button to update
+				if ( ! button ) {
+					return;
+				}
+
+				if ( ! subMenu.id ) {
+					subMenu.id = parentLi.id + '-sub-menu';
+				}
+
+				button.setAttribute( 'aria-controls', subMenu.id );
+			} );
+		}
+
 		/**
 		 * Dropdown click
 		 *

--- a/assets/js/dropdown-click.js
+++ b/assets/js/dropdown-click.js
@@ -52,10 +52,10 @@
 				}
 			}
 
+			var subMenuSelector = '.children';
+
 			if ( closestLi.querySelector( '.sub-menu' ) ) {
-				var subMenuSelector = '.sub-menu';
-			} else {
-				subMenuSelector = '.children';
+				subMenuSelector = '.sub-menu';
 			}
 
 			// Open the sub-menu

--- a/assets/js/dropdown-click.js
+++ b/assets/js/dropdown-click.js
@@ -7,7 +7,7 @@
 		/**
 		 * Dropdown click
 		 *
-		 * @param {Object} e The event.
+		 * @param {Object} e     The event.
 		 * @param {Object} _this The clicked item.
 		 */
 		var dropdownClick = function( e, _this ) {
@@ -60,7 +60,16 @@
 		// Open the sub-menu by clicking on the entire link element
 		if ( body.classList.contains( 'dropdown-click-menu-item' ) ) {
 			for ( i = 0; i < parentElementLinks.length; i++ ) {
-				parentElementLinks[ i ].addEventListener( 'click', dropdownClick, true );
+				parentElementLinks[ i ].addEventListener( 'click', dropdownClick, false );
+
+				parentElementLinks[ i ].addEventListener( 'keydown', function( e ) {
+					var _this = this;
+
+					if ( 'Enter' === e.key || ' ' === e.key ) {
+						e.preventDefault();
+						dropdownClick( e, _this );
+					}
+				}, false );
 			}
 		}
 
@@ -80,7 +89,8 @@
 				dropdownToggleLinks[ i ].addEventListener( 'keydown', function( e ) {
 					var _this = this;
 
-					if ( 'Enter' === e.key ) {
+					if ( 'Enter' === e.key || ' ' === e.key ) {
+						e.preventDefault();
 						dropdownClick( e, _this );
 					}
 				}, false );

--- a/assets/js/dropdown-click.js
+++ b/assets/js/dropdown-click.js
@@ -32,12 +32,24 @@
 			// Add sfHover class to parent li
 			closestLi.classList.toggle( 'sfHover' );
 
-			// Set aria-expanded on arrow
-			var dropdownToggle = closestLi.querySelector( '.dropdown-menu-toggle' );
-			if ( 'false' === dropdownToggle.getAttribute( 'aria-expanded' ) || ! dropdownToggle.getAttribute( 'aria-expanded' ) ) {
-				dropdownToggle.setAttribute( 'aria-expanded', 'true' );
-			} else {
-				dropdownToggle.setAttribute( 'aria-expanded', 'false' );
+			if ( body.classList.contains( 'dropdown-click-arrow' ) ) {
+				// Set aria-expanded on arrow
+				var dropdownToggle = closestLi.querySelector( '.dropdown-menu-toggle' );
+				if ( 'false' === dropdownToggle.getAttribute( 'aria-expanded' ) || ! dropdownToggle.getAttribute( 'aria-expanded' ) ) {
+					dropdownToggle.setAttribute( 'aria-expanded', 'true' );
+				} else {
+					dropdownToggle.setAttribute( 'aria-expanded', 'false' );
+				}
+			}
+
+			if ( body.classList.contains( 'dropdown-click-menu-item' ) && _this.tagName && 'A' === _this.tagName.toUpperCase() ) {
+				if ( 'false' === _this.getAttribute( 'aria-expanded' ) || ! _this.getAttribute( 'aria-expanded' ) ) {
+					_this.setAttribute( 'aria-expanded', 'true' );
+					_this.setAttribute( 'aria-label', generatepressDropdownClick.closeSubMenuLabel );
+				} else {
+					_this.setAttribute( 'aria-expanded', 'false' );
+					_this.setAttribute( 'aria-label', generatepressDropdownClick.openSubMenuLabel );
+				}
 			}
 
 			if ( closestLi.querySelector( '.sub-menu' ) ) {
@@ -76,9 +88,9 @@
 		// Open the sub-menu by clicking on a dropdown arrow
 		if ( body.classList.contains( 'dropdown-click-arrow' ) ) {
 			// Add a class to sub-menu items that are set to #
-			for ( i = 0; i < document.querySelectorAll( '.main-nav .menu-item-has-children > a' ).length; i++ ) {
-				if ( '#' === document.querySelectorAll( '.main-nav .menu-item-has-children > a' )[ i ].getAttribute( 'href' ) ) {
-					document.querySelectorAll( '.main-nav .menu-item-has-children > a' )[ i ].classList.add( 'menu-item-dropdown-click' );
+			for ( i = 0; i < parentElementLinks.length; i++ ) {
+				if ( '#' === parentElementLinks[ i ].getAttribute( 'href' ) ) {
+					parentElementLinks[ i ].classList.add( 'menu-item-dropdown-click' );
 				}
 			}
 
@@ -96,22 +108,46 @@
 				}, false );
 			}
 
-			for ( i = 0; i < document.querySelectorAll( '.main-nav .menu-item-has-children > a.menu-item-dropdown-click' ).length; i++ ) {
-				document.querySelectorAll( '.main-nav .menu-item-has-children > a.menu-item-dropdown-click' )[ i ].addEventListener( 'click', dropdownClick, false );
+			const menuItemDropdownClick = document.querySelectorAll( '.main-nav .menu-item-has-children > a.menu-item-dropdown-click' );
+
+			for ( i = 0; i < menuItemDropdownClick.length; i++ ) {
+				menuItemDropdownClick[ i ].addEventListener( 'click', dropdownClick, false );
+
+				menuItemDropdownClick[ i ].addEventListener( 'keydown', function( e ) {
+					var _this = this;
+
+					if ( 'Enter' === e.key || ' ' === e.key ) {
+						e.preventDefault();
+						dropdownClick( e, _this );
+					}
+				}, false );
 			}
 		}
 
 		var closeSubMenus = function() {
 			if ( document.querySelector( 'nav ul .toggled-on' ) ) {
 				var activeSubMenus = document.querySelectorAll( 'nav ul .toggled-on' );
-				var activeDropdownToggles = document.querySelectorAll( 'nav .dropdown-menu-toggle' );
+
 				for ( i = 0; i < activeSubMenus.length; i++ ) {
 					activeSubMenus[ i ].classList.remove( 'toggled-on' );
 					activeSubMenus[ i ].closest( '.sfHover' ).classList.remove( 'sfHover' );
 				}
 
-				for ( i = 0; i < activeDropdownToggles.length; i++ ) {
-					activeDropdownToggles[ i ].setAttribute( 'aria-expanded', 'false' );
+				if ( body.classList.contains( 'dropdown-click-arrow' ) ) {
+					var activeDropdownToggles = document.querySelectorAll( 'nav .dropdown-menu-toggle' );
+
+					for ( i = 0; i < activeDropdownToggles.length; i++ ) {
+						activeDropdownToggles[ i ].setAttribute( 'aria-expanded', 'false' );
+					}
+				}
+
+				if ( body.classList.contains( 'dropdown-click-menu-item' ) ) {
+					var activeDropdownLinks = document.querySelectorAll( 'nav .menu-item-has-children > a' );
+
+					for ( i = 0; i < activeDropdownLinks.length; i++ ) {
+						activeDropdownLinks[ i ].setAttribute( 'aria-expanded', 'false' );
+						activeDropdownLinks[ i ].setAttribute( 'aria-label', generatepressDropdownClick.openSubMenuLabel );
+					}
 				}
 			}
 		};

--- a/assets/js/dropdown-click.js
+++ b/assets/js/dropdown-click.js
@@ -5,27 +5,6 @@
 		var body = document.body,
 			i;
 
-		// Add missing aria roles and attributes for accessibility.
-		var allSubMenus = document.querySelectorAll( '.main-nav .sub-menu, .main-nav .children' );
-
-		if ( allSubMenus ) {
-			allSubMenus.forEach( function( subMenu ) {
-				var parentLi = subMenu.closest( 'li' );
-				var button = parentLi.querySelector( '[role="button"]' );
-
-				// Bail if no button to update
-				if ( ! button ) {
-					return;
-				}
-
-				if ( ! subMenu.id ) {
-					subMenu.id = parentLi.id + '-sub-menu';
-				}
-
-				button.setAttribute( 'aria-controls', subMenu.id );
-			} );
-		}
-
 		/**
 		 * Dropdown click
 		 *

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -88,7 +88,7 @@
 		/**
 		 * Start mobile menu toggle.
 		 *
-		 * @param {Object} e The event.
+		 * @param {Object} e     The event.
 		 * @param {Object} _this The clicked item.
 		 */
 		var toggleNav = function( e, _this ) {
@@ -166,7 +166,7 @@
 		/**
 		 * Open sub-menus
 		 *
-		 * @param {Object} e The event.
+		 * @param {Object} e     The event.
 		 * @param {Object} _this The clicked item.
 		 */
 		var toggleSubNav = function( e, _this ) {

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -1,5 +1,29 @@
 ( function() {
 	'use strict';
+	var allSubMenus = document.querySelectorAll( '.main-nav .sub-menu, .main-nav .children' );
+
+	// Add missing aria roles and attributes for accessibility.
+	if ( allSubMenus ) {
+		allSubMenus.forEach( function( subMenu ) {
+			var parentLi = subMenu.closest( 'li' );
+			var button = parentLi.querySelector( '.dropdown-menu-toggle[role="button"]' );
+
+			if ( ! subMenu.id ) {
+				subMenu.id = parentLi.id + '-sub-menu';
+			}
+
+			// Bail if no button to update
+			if ( ! button ) {
+				button = parentLi.querySelector( 'a[role="button"]' );
+
+				if ( ! button ) {
+					return;
+				}
+			}
+
+			button.setAttribute( 'aria-controls', subMenu.id );
+		} );
+	}
 
 	if ( 'querySelector' in document && 'addEventListener' in window ) {
 		/**
@@ -54,10 +78,15 @@
 				var dropdownItems = nav.querySelectorAll( 'li.menu-item-has-children' );
 
 				for ( i = 0; i < dropdownItems.length; i++ ) {
-					dropdownItems[ i ].querySelector( '.dropdown-menu-toggle' ).setAttribute( 'tabindex', '0' );
-					dropdownItems[ i ].querySelector( '.dropdown-menu-toggle' ).setAttribute( 'role', 'button' );
-					dropdownItems[ i ].querySelector( '.dropdown-menu-toggle' ).setAttribute( 'aria-expanded', 'false' );
-					dropdownItems[ i ].querySelector( '.dropdown-menu-toggle' ).setAttribute( 'aria-label', generatepressMenu.openSubMenuLabel );
+					var toggle = dropdownItems[ i ].querySelector( '.dropdown-menu-toggle' );
+					var parentLi = toggle.closest( 'li' );
+					var subMenu = parentLi.querySelector( '.sub-menu, .children' );
+
+					toggle.setAttribute( 'tabindex', '0' );
+					toggle.setAttribute( 'role', 'button' );
+					toggle.setAttribute( 'aria-expanded', 'false' );
+					toggle.setAttribute( 'aria-controls', subMenu.id );
+					toggle.setAttribute( 'aria-label', generatepressMenu.openSubMenuLabel );
 				}
 			}
 		};
@@ -70,6 +99,7 @@
 					dropdownItems[ i ].querySelector( '.dropdown-menu-toggle' ).removeAttribute( 'tabindex' );
 					dropdownItems[ i ].querySelector( '.dropdown-menu-toggle' ).setAttribute( 'role', 'presentation' );
 					dropdownItems[ i ].querySelector( '.dropdown-menu-toggle' ).removeAttribute( 'aria-expanded' );
+					dropdownItems[ i ].querySelector( '.dropdown-menu-toggle' ).removeAttribute( 'aria-controls' );
 					dropdownItems[ i ].querySelector( '.dropdown-menu-toggle' ).removeAttribute( 'aria-label' );
 				}
 			}

--- a/inc/general.php
+++ b/inc/general.php
@@ -91,6 +91,15 @@ if ( ! function_exists( 'generate_scripts' ) ) {
 
 		if ( 'click' === generate_get_option( 'nav_dropdown_type' ) || 'click-arrow' === generate_get_option( 'nav_dropdown_type' ) ) {
 			wp_enqueue_script( 'generate-dropdown-click', $dir_uri . "/assets/js/dropdown-click{$suffix}.js", array(), GENERATE_VERSION, true );
+
+			wp_localize_script(
+				'generate-dropdown-click',
+				'generatepressDropdownClick',
+				array(
+					'openSubMenuLabel' => esc_attr__( 'Open Sub-Menu', 'generatepress' ),
+					'closeSubMenuLabel' => esc_attr__( 'Close Sub-Menu', 'generatepress' ),
+				)
+			);
 		}
 
 		if ( apply_filters( 'generate_enable_modal_script', false ) ) {

--- a/inc/structure/navigation.php
+++ b/inc/structure/navigation.php
@@ -365,12 +365,24 @@ if ( ! function_exists( 'generate_dropdown_icon_to_menu_link' ) ) {
 	 * @return string The menu item.
 	 */
 	function generate_dropdown_icon_to_menu_link( $title, $item, $args, $depth ) {
-		$role = 'presentation';
-		$tabindex = '';
+		$role        = 'presentation';
+		$tabindex    = '';
+		$aria_label  = '';
+		$aria_hidden = ' aria-hidden="true"';
+		$style       = '';
 
 		if ( 'click-arrow' === generate_get_option( 'nav_dropdown_type' ) ) {
 			$role = 'button';
 			$tabindex = ' tabindex="0"';
+			$aria_label = sprintf(
+				' aria-label="%s"',
+				esc_attr__( 'Expand sub menu', 'generatepress' )
+			);
+			$aria_hidden = '';
+		}
+
+		if ( 'click' === generate_get_option( 'nav_dropdown_type' ) ) {
+			$style = ' style="pointer-events: none;"';
 		}
 
 		if ( isset( $args->container_class ) && 'main-nav' === $args->container_class ) {
@@ -417,13 +429,46 @@ if ( ! function_exists( 'generate_dropdown_icon_to_menu_link' ) ) {
 					}
 
 					$icon = generate_get_svg_icon( 'arrow' . $arrow_direction );
-					$title = $title . '<span role="' . $role . '" class="dropdown-menu-toggle"' . $tabindex . '>' . $icon . '</span>';
+					$title = $title . '<span role="' . $role . '" class="dropdown-menu-toggle"' . $tabindex . $aria_label . $aria_hidden . $style . '>' . $icon . '</span>';
 				}
 			}
 		}
 
 		return $title;
 	}
+}
+
+add_filter( 'nav_menu_link_attributes', 'generate_set_menu_item_link_attributes', 10, 4 );
+/**
+ * Add attributes to menu items.
+ *
+ * @since 3.5.0
+ *
+ * @param array    $atts The menu item attributes.
+ * @param WP_Post  $item The current menu item.
+ * @param stdClass $args The menu item args.
+ * @param int      $depth The depth of the menu item.
+ * @return array The menu item attributes.
+ */
+function generate_set_menu_item_link_attributes( $atts, $item, $args, $depth ) {
+	if ( ! isset( $args->container_class ) || 'main-nav' !== $args->container_class ) {
+		return $atts;
+	}
+
+	if ( 'click' !== generate_get_option( 'nav_dropdown_type' ) ) {
+		return $atts;
+	}
+
+	foreach ( $item->classes as $value ) {
+		if ( 'menu-item-has-children' === $value ) {
+			$atts['role'] = 'button';
+			$atts['aria-expanded'] = 'false';
+			$atts['aria-haspopup'] = 'true';
+			$atts['aria-label'] = esc_attr__( 'Open Sub-Menu', 'generatepress' );
+		}
+	}
+
+	return $atts;
 }
 
 if ( ! function_exists( 'generate_navigation_search' ) ) {

--- a/inc/structure/navigation.php
+++ b/inc/structure/navigation.php
@@ -368,7 +368,6 @@ if ( ! function_exists( 'generate_dropdown_icon_to_menu_link' ) ) {
 		$role        = 'presentation';
 		$tabindex    = '';
 		$aria_label  = '';
-		$aria_hidden = ' aria-hidden="true"';
 		$style       = '';
 
 		if ( 'click-arrow' === generate_get_option( 'nav_dropdown_type' ) ) {
@@ -378,7 +377,6 @@ if ( ! function_exists( 'generate_dropdown_icon_to_menu_link' ) ) {
 				' aria-label="%s"',
 				esc_attr__( 'Open Sub-Menu', 'generatepress' )
 			);
-			$aria_hidden = '';
 		}
 
 		if ( 'click' === generate_get_option( 'nav_dropdown_type' ) ) {
@@ -429,7 +427,7 @@ if ( ! function_exists( 'generate_dropdown_icon_to_menu_link' ) ) {
 					}
 
 					$icon = generate_get_svg_icon( 'arrow' . $arrow_direction );
-					$title = $title . '<span role="' . $role . '" class="dropdown-menu-toggle"' . $tabindex . $aria_label . $aria_hidden . $style . '>' . $icon . '</span>';
+					$title = $title . '<span role="' . $role . '" class="dropdown-menu-toggle"' . $tabindex . $aria_label . $style . '>' . $icon . '</span>';
 				}
 			}
 		}
@@ -440,7 +438,7 @@ if ( ! function_exists( 'generate_dropdown_icon_to_menu_link' ) ) {
 
 add_filter( 'nav_menu_link_attributes', 'generate_set_menu_item_link_attributes', 10, 4 );
 /**
- * Add attributes to menu items.
+ * Add attributes to the menu item link when using the Click - Menu Item option.
  *
  * @since 3.5.0
  *
@@ -459,13 +457,11 @@ function generate_set_menu_item_link_attributes( $atts, $item, $args, $depth ) {
 		return $atts;
 	}
 
-	foreach ( $item->classes as $value ) {
-		if ( 'menu-item-has-children' === $value ) {
-			$atts['role'] = 'button';
-			$atts['aria-expanded'] = 'false';
-			$atts['aria-haspopup'] = 'true';
-			$atts['aria-label'] = esc_attr__( 'Open Sub-Menu', 'generatepress' );
-		}
+	if ( in_array( 'menu-item-has-children', $item->classes, true ) ) {
+		$atts['role'] = 'button';
+		$atts['aria-expanded'] = 'false';
+		$atts['aria-haspopup'] = 'true';
+		$atts['aria-label'] = esc_attr__( 'Open Sub-Menu', 'generatepress' );
 	}
 
 	return $atts;

--- a/inc/structure/navigation.php
+++ b/inc/structure/navigation.php
@@ -376,7 +376,7 @@ if ( ! function_exists( 'generate_dropdown_icon_to_menu_link' ) ) {
 			$tabindex = ' tabindex="0"';
 			$aria_label = sprintf(
 				' aria-label="%s"',
-				esc_attr__( 'Expand sub menu', 'generatepress' )
+				esc_attr__( 'Open Sub-Menu', 'generatepress' )
 			);
 			$aria_hidden = '';
 		}


### PR DESCRIPTION
When using the "Click - Menu Item" and "Click - Arrow" options in "Customize > Layout > Primary Navigation", the dropdown menus were not opening using the spacebar.