### PR TITLE
Fix: `readme.txt` versions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,8 @@ Donate link: https://generatepress.com/ongoing-development/
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Tags: two-columns, three-columns, one-column, right-sidebar, left-sidebar, footer-widgets, blog, e-commerce, flexible-header, full-width-template, buddypress, custom-header, custom-background, custom-menu, custom-colors, sticky-post, threaded-comments, translation-ready, rtl-language-support, featured-images, theme-options
-Requires at least: 7.4
+Requires at least: 6.1
+Requires PHP: 7.4
 Tested up to: 6.6
 Stable tag: 3.5.0
 


### PR DESCRIPTION
We were incorrectly using `Requires at least` for the PHP version.