### PR TITLE
Fix: Remove `appearance-tools`

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -35,7 +35,6 @@ if ( ! function_exists( 'generate_setup' ) ) {
 		add_theme_support( 'customize-selective-refresh-widgets' );
 		add_theme_support( 'align-wide' );
 		add_theme_support( 'responsive-embeds' );
-		add_theme_support( 'appearance-tools' );
 
 		$color_palette = generate_get_editor_color_palette();
 


### PR DESCRIPTION
The `appearance-tools` theme supports is adding destructive CSS to the frontend of sites when using core blocks like the Group and Quote blocks.