### PR TITLE
Fix: Dropdown click issue in off-canvas panel

### DIFF
--- a/assets/js/dropdown-click.js
+++ b/assets/js/dropdown-click.js
@@ -73,7 +73,7 @@
 		// Open the sub-menu by clicking on the entire link element
 		if ( body.classList.contains( 'dropdown-click-menu-item' ) ) {
 			for ( i = 0; i < parentElementLinks.length; i++ ) {
-				parentElementLinks[ i ].addEventListener( 'click', dropdownClick, false );
+				parentElementLinks[ i ].addEventListener( 'click', dropdownClick, true );
 
 				parentElementLinks[ i ].addEventListener( 'keydown', function( e ) {
 					var _this = this;


### PR DESCRIPTION
Related:
https://generate.support/topic/off-canvas-menu-disappears-before-i-can-select-a-category-sub-category/
https://generate.support/topic/mobile-slide-out-menu-closes-when-selecting-menu-item/