### PR TITLE
Tweak: Use `wp_print_inline_script_tag` for inline scripts

### DIFF
--- a/inc/general.php
+++ b/inc/general.php
@@ -74,31 +74,35 @@ if ( ! function_exists( 'generate_scripts' ) ) {
 
 		if ( generate_has_active_menu() ) {
 			wp_enqueue_script( 'generate-menu', $dir_uri . "/assets/js/menu{$suffix}.js", array(), GENERATE_VERSION, true );
-		}
 
-		wp_localize_script(
-			'generate-menu',
-			'generatepressMenu',
-			apply_filters(
+			$menu_script_args = apply_filters(
 				'generate_localize_js_args',
 				array(
 					'toggleOpenedSubMenus' => true,
-					'openSubMenuLabel' => esc_attr__( 'Open Sub-Menu', 'generatepress' ),
-					'closeSubMenuLabel' => esc_attr__( 'Close Sub-Menu', 'generatepress' ),
+					'openSubMenuLabel'     => esc_attr__( 'Open Sub-Menu', 'generatepress' ),
+					'closeSubMenuLabel'    => esc_attr__( 'Close Sub-Menu', 'generatepress' ),
 				)
-			)
-		);
+			);
+
+			generate_add_inline_script(
+				'generate-menu',
+				$menu_script_args,
+				'generatepressMenu'
+			);
+		}
 
 		if ( 'click' === generate_get_option( 'nav_dropdown_type' ) || 'click-arrow' === generate_get_option( 'nav_dropdown_type' ) ) {
 			wp_enqueue_script( 'generate-dropdown-click', $dir_uri . "/assets/js/dropdown-click{$suffix}.js", array(), GENERATE_VERSION, true );
 
-			wp_localize_script(
+			$dropdown_click_args = array(
+				'openSubMenuLabel'  => esc_attr__( 'Open Sub-Menu', 'generatepress' ),
+				'closeSubMenuLabel' => esc_attr__( 'Close Sub-Menu', 'generatepress' ),
+			);
+
+			generate_add_inline_script(
 				'generate-dropdown-click',
-				'generatepressDropdownClick',
-				array(
-					'openSubMenuLabel' => esc_attr__( 'Open Sub-Menu', 'generatepress' ),
-					'closeSubMenuLabel' => esc_attr__( 'Close Sub-Menu', 'generatepress' ),
-				)
+				$dropdown_click_args,
+				'generatepressDropdownClick'
 			);
 		}
 
@@ -109,28 +113,32 @@ if ( ! function_exists( 'generate_scripts' ) ) {
 		if ( 'enable' === generate_get_option( 'nav_search' ) ) {
 			wp_enqueue_script( 'generate-navigation-search', $dir_uri . "/assets/js/navigation-search{$suffix}.js", array(), GENERATE_VERSION, true );
 
-			wp_localize_script(
+			$nav_search_args = array(
+				'open'  => esc_attr__( 'Open Search Bar', 'generatepress' ),
+				'close' => esc_attr__( 'Close Search Bar', 'generatepress' ),
+			);
+
+			generate_add_inline_script(
 				'generate-navigation-search',
-				'generatepressNavSearch',
-				array(
-					'open' => esc_attr__( 'Open Search Bar', 'generatepress' ),
-					'close' => esc_attr__( 'Close Search Bar', 'generatepress' ),
-				)
+				$nav_search_args,
+				'generatepressNavSearch'
 			);
 		}
 
 		if ( 'enable' === generate_get_option( 'back_to_top' ) ) {
 			wp_enqueue_script( 'generate-back-to-top', $dir_uri . "/assets/js/back-to-top{$suffix}.js", array(), GENERATE_VERSION, true );
 
-			wp_localize_script(
-				'generate-back-to-top',
-				'generatepressBackToTop',
-				apply_filters(
-					'generate_back_to_top_js_args',
-					array(
-						'smooth' => true,
-					)
+			$back_to_top_args = apply_filters(
+				'generate_back_to_top_js_args',
+				array(
+					'smooth' => true,
 				)
+			);
+
+			generate_add_inline_script(
+				'generate-back-to-top',
+				$back_to_top_args,
+				'generatepressBackToTop'
 			);
 		}
 

--- a/inc/general.php
+++ b/inc/general.php
@@ -482,11 +482,12 @@ add_action( 'wp_footer', 'generate_do_a11y_scripts' );
  * @since 3.1.0
  */
 function generate_do_a11y_scripts() {
-	if ( apply_filters( 'generate_print_a11y_script', true ) ) {
-		// Add our small a11y script inline.
-		printf(
-			'<script id="generate-a11y">%s</script>',
-			'!function(){"use strict";if("querySelector"in document&&"addEventListener"in window){var e=document.body;e.addEventListener("mousedown",function(){e.classList.add("using-mouse")}),e.addEventListener("keydown",function(){e.classList.remove("using-mouse")})}}();'
+	if ( apply_filters( 'generate_print_a11y_script', true ) && function_exists( 'wp_print_inline_script_tag' ) ) {
+		wp_print_inline_script_tag(
+			'!function(){"use strict";if("querySelector"in document&&"addEventListener"in window){var e=document.body;e.addEventListener("mousedown",function(){e.classList.add("using-mouse")}),e.addEventListener("keydown",function(){e.classList.remove("using-mouse")})}}();',
+			array(
+				'id' => 'generate-a11y',
+			)
 		);
 	}
 }

--- a/inc/theme-functions.php
+++ b/inc/theme-functions.php
@@ -826,3 +826,19 @@ function generate_has_active_menu() {
 function generate_is_using_dynamic_typography() {
 	return generate_get_option( 'use_dynamic_typography' );
 }
+
+/**
+ * Add inline script.
+ *
+ * @param string $handle The script handle to attach the inline script to.
+ * @param array  $data   The data to be passed to the script.
+ * @param string $var    The JavaScript variable name to assign the data to.
+ * @param string $position The position to add the inline script.
+ */
+function generate_add_inline_script( $handle, $data, $var, $position = 'before' ) {
+	if ( ! empty( $data ) ) {
+		$json_data = wp_json_encode( $data );
+		$inline_script = "var $var = $json_data;";
+		wp_add_inline_script( $handle, $inline_script, $position );
+	}
+}


### PR DESCRIPTION
closes https://github.com/tomusborne/generatepress/issues/659
context https://make.wordpress.org/core/2021/02/23/introducing-script-attributes-related-functions-in-wordpress-5-7/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the process for integrating dynamic data into interactive elements (e.g., navigation menus, dropdowns, search, and back-to-top features) to ensure consistency and maintainability.
  
- **New Features**
  - Introduced a flexible mechanism for adding inline scripts that underpins improved handling of dynamic settings for enhanced frontend interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->